### PR TITLE
fixing alting pdf for m1 processors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
       - "host.docker.internal:host-gateway"
   altinn_platform_pdf:
     container_name: altinn-pdf
+    platform: linux/amd64
     image: ghcr.io/altinn/altinn-pdf:latest
     restart: always
     networks:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The legacy `altinn-pdf` doesn't support the new M1/2 processors from Apple. This minor change make it run in compability mode, which is totally fine for this service.

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
