### PR TITLE
Ignore user file generated by Visual Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ bld/
 msbuild.log
 AltinnPlatformLocal/
 /.vs/LocalTest
+*.user


### PR DESCRIPTION
The LocalTest.csproj.user must be ignored by git.