### PR TITLE
Do not prompt for party preference

### DIFF
--- a/testdata/Profile/User/1001.json
+++ b/testdata/Profile/User/1001.json
@@ -1,14 +1,13 @@
 {
-    "UserId": 1001,
-    "UserName": "PengelensPartner",
-    "PhoneNumber": "12345678",
-    "Email": "test@test.com",
-    "PartyId": 510001,
-    "Party": {
-  
-    },
-    "UserType": 0,
-    "ProfileSettingPreference": {
-      "Language": "nb"
-    }
+  "UserId": 1001,
+  "UserName": "PengelensPartner",
+  "PhoneNumber": "12345678",
+  "Email": "test@test.com",
+  "PartyId": 510001,
+  "Party": {},
+  "UserType": 0,
+  "ProfileSettingPreference": {
+    "Language": "nb",
+    "doNotPromptForParty": true
   }
+}

--- a/testdata/Profile/User/1002.json
+++ b/testdata/Profile/User/1002.json
@@ -1,14 +1,13 @@
 {
-    "UserId": 1002,
-    "UserName": "GjentagendeForelder",
-    "PhoneNumber": "12345678",
-    "Email": "test@test.com",
-    "PartyId": 510002,
-    "Party": {
-  
-    },
-    "UserType": 0,
-    "ProfileSettingPreference": {
-      "Language": "nb"
-    }
+  "UserId": 1002,
+  "UserName": "GjentagendeForelder",
+  "PhoneNumber": "12345678",
+  "Email": "test@test.com",
+  "PartyId": 510002,
+  "Party": {},
+  "UserType": 0,
+  "ProfileSettingPreference": {
+    "Language": "nb",
+    "doNotPromptForParty": true
   }
+}

--- a/testdata/Profile/User/1003.json
+++ b/testdata/Profile/User/1003.json
@@ -1,14 +1,13 @@
 {
-    "UserId": 1003,
-    "UserName": "RikForelder",
-    "PhoneNumber": "12345678",
-    "Email": "test@test.com",
-    "PartyId": 510003,
-    "Party": {
-  
-    },
-    "UserType": 0,
-    "ProfileSettingPreference": {
-      "Language": "nb"
-    }
+  "UserId": 1003,
+  "UserName": "RikForelder",
+  "PhoneNumber": "12345678",
+  "Email": "test@test.com",
+  "PartyId": 510003,
+  "Party": {},
+  "UserType": 0,
+  "ProfileSettingPreference": {
+    "Language": "nb",
+    "doNotPromptForParty": true
   }
+}

--- a/testdata/Profile/User/12345.json
+++ b/testdata/Profile/User/12345.json
@@ -4,11 +4,10 @@
   "PhoneNumber": "12345678",
   "Email": "test@test.com",
   "PartyId": 512345,
-  "Party": {
-
-  },
+  "Party": {},
   "UserType": 0,
   "ProfileSettingPreference": {
-	"Language": "nb"
+    "Language": "nb",
+    "doNotPromptForParty": true
   }
 }

--- a/testdata/Profile/User/1337.json
+++ b/testdata/Profile/User/1337.json
@@ -4,11 +4,10 @@
   "PhoneNumber": "90001337",
   "Email": "1337@altinnstudiotestusers.com",
   "PartyId": 501337,
-  "Party": {
-
-  },
+  "Party": {},
   "UserType": 1,
   "ProfileSettingPreference": {
-	"Language": "nn"
+    "Language": "nn",
+    "doNotPromptForParty": true
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When the below issue gets fixed, the `doNotPromptForParty` preference will actually have an effect in app-frontend, so I'm setting this to true for the test users so that we don't have to go through party selection every time.

## Related Issue(s)
- https://github.com/Altinn/app-frontend-react/issues/268
