### PR TITLE
Add a button to refresh authentication without starting new instance

### DIFF
--- a/src/Controllers/HomeController.cs
+++ b/src/Controllers/HomeController.cs
@@ -142,7 +142,7 @@ namespace LocalTest.Controllers
         /// <param name="startAppModel">An object with information about app and user.</param>
         /// <returns>Redirects to returnUrl</returns>
         [HttpPost]
-        public async Task<ActionResult> LogInTestUser(StartAppModel startAppModel)
+        public async Task<ActionResult> LogInTestUser(string action, StartAppModel startAppModel)
         {
             if (startAppModel.AuthenticationLevel != "-1")
             {
@@ -151,6 +151,11 @@ namespace LocalTest.Controllers
 
                 string token = await _authenticationService.GenerateTokenForProfile(profile, authenticationLevel);
                 CreateJwtCookieAndAppendToResponse(token, startAppModel.PartyId, startAppModel.UserSelect);
+            }
+
+            if (action.Equals("reauthenticate"))
+            {
+                return NoContent();
             }
 
             if (startAppModel.AppPathSelection?.Equals("accessmanagement") == true)

--- a/src/Views/Home/Index.cshtml
+++ b/src/Views/Home/Index.cshtml
@@ -84,6 +84,7 @@
         <label for="exampleInputEmail1">Select your authentication level</label>
         @Html.DropDownListFor(model => model.AuthenticationLevel, Model.AuthenticationLevels, new { Class = "form-control" })
       </div>
+      <button type="submit" class="btn btn-primary" name="action" value="reauthenticate">Refresh authentication</button>
       @if(Model.AppModeIsHttp)
       {
         <div class="form-group">
@@ -94,7 +95,7 @@
           <input class="form-control" type="file" id="prefill" name="prefill" accept=".xml"/>
         </div>
       }
-      <button type="submit" class="btn btn-primary">Proceed to app</button>
+      <button type="submit" class="btn btn-primary" name="action" value="start">Proceed to app</button>
     }
 
     <div class="alert alert-light" role="alert">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add a button to ease the process of changing/refreshing the authentication cookie without starting a new instance of the application.
Button post to the same endpoint but if action is reauthenticate the method returns 204 no content after cookie is updated.
Makes testing of apps where different users with different roles are needed to complete the entire process

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
