### PR TITLE
Align the authorization policy of PartiesController for Register with the register component authorization policy

### DIFF
--- a/src/Controllers/Register/PartiesController.cs
+++ b/src/Controllers/Register/PartiesController.cs
@@ -11,7 +11,6 @@ namespace Altinn.Platform.Register.Controllers
     /// <summary>
     /// The parties controller provides access to party information in the SBL Register component.
     /// </summary>
-    [Authorize]
     [Route("register/api/v1/parties")]
     public class PartiesController : Controller
     {


### PR DESCRIPTION
## Description
I have removed the Authorize attribute on PartiesController for Register to allow services without a User context to call its actions. In the actual Register component, the "PlatformAccess" policy is applied([link](https://github.com/Altinn/altinn-register/blob/e5b7bfaeecc1e1eaeeb44837d2c3032f79119501/src/Controllers/PartiesController.cs#L22)), indicating that only services should be authorized to call it. Because no PlatformAccessToken is present when testing an app locally, calls to this controller will be unauthorized with 401 status code. Hence why I have removed the attribute.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out) 
  `Not applicable`
- [ ] All tests run green
  `Not applicable`

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
  `not applicable`
