### PR TITLE
Remove toLower call when adding org claim as this will fail if the username based org has uppercase characters somewhere.

### DIFF
--- a/src/Services/Authentication/Implementation/AuthenticationService.cs
+++ b/src/Services/Authentication/Implementation/AuthenticationService.cs
@@ -66,7 +66,7 @@ public class AuthenticationService : IAuthentication
 
         List<Claim> claims = new List<Claim>();
         string issuer = _generalSettings.Hostname;
-        claims.Add(new Claim(AltinnCoreClaimTypes.Org, org.ToLower(), ClaimValueTypes.String, issuer));
+        claims.Add(new Claim(AltinnCoreClaimTypes.Org, org, ClaimValueTypes.String, issuer));
         // 3 is the default level for altinn tokens form Maskinporten
         claims.Add(new Claim(AltinnCoreClaimTypes.AuthenticationLevel, "3", ClaimValueTypes.Integer32, issuer));
         claims.Add(new Claim("urn:altinn:scope", "altinn:serviceowner/instances.read", ClaimValueTypes.String, issuer));


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes an issue where it's assumed that org short codes always are lowercase. This is true for production, but not localtest/development.

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
