### PR TITLE
Various updates to app-localtest

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,33 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Core Launch (web)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            "program": "${workspaceFolder}/src/bin/Debug/net6.0/LocalTest.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/src",
+            "stopAtEntry": false,
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "\\bNow listening on:\\s+(https?://\\S+)"
+            },
+            "env": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+            },
+            "sourceFileMap": {
+                "/Views": "${workspaceFolder}/Views"
+            }
+        },
+        {
+            "name": ".NET Core Attach",
+            "type": "coreclr",
+            "request": "attach"
+        }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,41 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "build",
+                "${workspaceFolder}/LocalTest.sln",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "publish",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "publish",
+                "${workspaceFolder}/LocalTest.sln",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "watch",
+            "command": "dotnet",
+            "type": "process",
+            "args": [
+                "watch",
+                "run",
+                "--project",
+                "${workspaceFolder}/LocalTest.sln"
+            ],
+            "problemMatcher": "$msCompile"
+        }
+    ]
+}

--- a/loadbalancer/templates/nginx.conf.conf
+++ b/loadbalancer/templates/nginx.conf.conf
@@ -70,6 +70,7 @@ http {
 
 		location = / {
         proxy_pass          http://localtest/Home/;
+        sub_filter '<script src="/_framework/aspnetcore-browser-refresh.js"></script>' '<script src="/Home/_framework/aspnetcore-browser-refresh.js"></script>';
 		}
 
 		location / {
@@ -81,8 +82,13 @@ http {
         proxy_cookie_domain altinn3local.no local.altinn.cloud;
 		}
 
+    location /Home/_framework/ {
+        proxy_pass            http://localtest/_framework/;
+    }
+
 		location /Home/ {
 			  proxy_pass		      http://localtest/Home/;
+        sub_filter '<script src="/_framework/aspnetcore-browser-refresh.js"></script>' '<script src="/Home/_framework/aspnetcore-browser-refresh.js"></script>';
 		}
 
     location /receipt/ {

--- a/src/Controllers/HomeController.cs
+++ b/src/Controllers/HomeController.cs
@@ -240,7 +240,7 @@ namespace LocalTest.Controllers
         public static readonly string FRONTEND_URL_COOKIE_NAME = "frontendVersion";
 
         [HttpGet]
-        public async Task<ActionResult> FrontendVersion([FromServices]HttpClient client)
+        public async Task<ActionResult> FrontendVersion([FromServices] HttpClient client)
         {
             var versionFromCookie = HttpContext.Request.Cookies[FRONTEND_URL_COOKIE_NAME];
 
@@ -315,7 +315,7 @@ namespace LocalTest.Controllers
 
                 var userParties = await _partiesService.GetParties(properProfile.UserId);
 
-                if (userParties.Count == 1)
+                if (userParties.Count == 1 && userParties.First().PartyId == properProfile.PartyId)
                 {
                     // Don't add singe party users to a group
                     var party = userParties.First();
@@ -349,7 +349,7 @@ namespace LocalTest.Controllers
 
         private async Task<int> GetAppAuthLevel(bool isHttp, IEnumerable<SelectListItem> testApps)
         {
-            if(!isHttp)
+            if (!isHttp)
             {
                 return 2;
             }


### PR DESCRIPTION
While working on https://github.com/Altinn/app-localtest/issues/59, I discovered a few minor issues, that I think makes sense to review separately from the main code.

* Add vscode debug files
* add support for proxying /_framework/aspnetcore-browser-refresh.js calls through the loadbalancer by rewriting the both the url and the script reference.
* Fix a few C# formatting isuses


## Related Issue(s)
-  https://github.com/Altinn/app-localtest/issues/59

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

