### PR TITLE
Add page for uploading json files from tenor to configure persons and orgs

### DIFF
--- a/loadbalancer/templates/nginx.conf.conf
+++ b/loadbalancer/templates/nginx.conf.conf
@@ -31,7 +31,7 @@ http {
 
     sendfile on;
 
-	  upstream localtest {
+    upstream localtest {
         server host.docker.internal:5101;
     }
 
@@ -58,7 +58,7 @@ http {
     }
 
     server {
-		    listen 80 default_server;
+        listen 80 default_server;
         server_name ${TEST_DOMAIN};
 
         proxy_redirect      off;
@@ -68,50 +68,50 @@ http {
 
     error_page 502 /502LocalTest.html;
 
-		location = / {
+    location = / {
         proxy_pass          http://localtest/Home/;
         sub_filter '<script src="/_framework/aspnetcore-browser-refresh.js"></script>' '<script src="/Home/_framework/aspnetcore-browser-refresh.js"></script>';
-		}
+    }
 
-		location / {
+    location / {
         #Support using Local js, when a cookie value is set
         sub_filter_once off;
         sub_filter 'https://altinncdn.no/toolkits/altinn-app-frontend/3/' $LOCAL_SUB_FILTER;
         proxy_pass          http://app/;
         error_page 502 /502App.html;
         proxy_cookie_domain altinn3local.no local.altinn.cloud;
-		}
-
-    location /Home/_framework/ {
-        proxy_pass            http://localtest/_framework/;
     }
 
-		location /Home/ {
-			  proxy_pass		      http://localtest/Home/;
+    location /Home/_framework/ {
+        proxy_pass          http://localtest/_framework/;
+    }
+
+    location /Home/ {
+        proxy_pass          http://localtest/Home/;
         sub_filter '<script src="/_framework/aspnetcore-browser-refresh.js"></script>' '<script src="/Home/_framework/aspnetcore-browser-refresh.js"></script>';
-		}
+    }
 
     location /receipt/ {
-			  proxy_pass		      http://receiptcomp/receipt/;
-			  error_page 502 /502Receipt.html;
-		}
+        proxy_pass          http://receiptcomp/receipt/;
+        error_page 502 /502Receipt.html;
+    }
 
     location /accessmanagement/ {
-			  proxy_pass		      http://accessmanagementcomp/accessmanagement/;
+        proxy_pass          http://accessmanagementcomp/accessmanagement/;
         error_page 502 /502Accessmanagement.html;
-		}
+    }
 
     location /storage/ {
-			  proxy_pass		      http://localtest/storage/;
-		}
+        proxy_pass          http://localtest/storage/;
+    }
 
     location /pdfservice/ {
         proxy_pass          http://pdfservice/;
     }
 
     location /localtestresources/ {
-			  proxy_pass		      http://localtest/localtestresources/;
-		}
+        proxy_pass          http://localtest/localtestresources/;
+    }
     location /LocalPlatformStorage/ {
       proxy_pass           http://localtest/LocalPlatformStorage/;
     }
@@ -128,5 +128,5 @@ http {
       root /www;
     }
 
-	}
+  }
 }

--- a/loadbalancer/templates/nginx.conf.conf
+++ b/loadbalancer/templates/nginx.conf.conf
@@ -113,7 +113,8 @@ http {
         proxy_pass          http://localtest/localtestresources/;
     }
     location /LocalPlatformStorage/ {
-      proxy_pass           http://localtest/LocalPlatformStorage/;
+        proxy_pass           http://localtest/LocalPlatformStorage/;
+        sub_filter '<script src="/_framework/aspnetcore-browser-refresh.js"></script>' '';
     }
     location /502LocalTest.html {
       root /www;

--- a/src/Configuration/LocalPlatformSettings.cs
+++ b/src/Configuration/LocalPlatformSettings.cs
@@ -68,5 +68,7 @@ namespace LocalTest.Configuration
         public string RolesFolder { get; set; } = "roles/";
 
         public string ClaimsFolder { get; set; } = "claims/";
+
+        public string TenorDataFolder { get; set; } = "tenorUsers";
     }
 }

--- a/src/Controllers/DebugUsersController.cs
+++ b/src/Controllers/DebugUsersController.cs
@@ -1,0 +1,74 @@
+#nullable enable
+using System.Text.Json;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+using Altinn.Platform.Storage.Repository;
+
+using LocalTest.Configuration;
+using LocalTest.Models;
+using LocalTest.Services.LocalApp.Interface;
+
+using LocalTest.Services.TestData;
+using Microsoft.AspNetCore.Authorization;
+
+namespace LocalTest.Controllers;
+
+[Route("Home/[controller]/[action]")]
+public class DebugUsersController : Controller
+{
+    private readonly TenorDataRepository _tenorDataRepository;
+    private readonly LocalPlatformSettings _localPlatformSettings;
+    private readonly ILocalApp _localApp;
+
+    public DebugUsersController(
+        TenorDataRepository tenorDataRepository,
+        IOptions<LocalPlatformSettings> localPlatformSettings,
+        ILocalApp localApp)
+    {
+        _tenorDataRepository = tenorDataRepository;
+        _localPlatformSettings = localPlatformSettings.Value;
+        _localApp = localApp;
+    }
+
+        // Debugging endpoint
+        [AllowAnonymous]
+        public async Task<IActionResult> LocalTestUsersRaw()
+        {
+            var localData = await TestDataDiskReader.ReadFromDisk(_localPlatformSettings.LocalTestingStaticTestDataPath);
+
+            return Json(localData);
+        }
+
+        //Debugging endpoint
+        [AllowAnonymous]
+        public async Task<IActionResult> LocalTestUsers()
+        {
+            var localData = await TestDataDiskReader.ReadFromDisk(_localPlatformSettings.LocalTestingStaticTestDataPath);
+            var constructedAppData = AppTestDataModel.FromTestDataModel(localData);
+
+            return Json(constructedAppData);
+        }
+
+        // Debugging endpoint
+        [AllowAnonymous]
+        public async Task<IActionResult> LocalTestUsersRoundTrip()
+        {
+            var localData = await TestDataDiskReader.ReadFromDisk(_localPlatformSettings.LocalTestingStaticTestDataPath);
+            var constructedAppData = AppTestDataModel.FromTestDataModel(localData);
+
+            return Json(constructedAppData.GetTestDataModel());
+        }
+
+        // Debugging endpoint
+        [AllowAnonymous]
+        public async Task<IActionResult> ShowTenorUsers([FromServices] TenorDataRepository tenorDataRepository)
+        {
+            var localData = await tenorDataRepository.GetAppTestDataModel();
+
+            return Json(localData);
+        }
+
+
+}

--- a/src/Controllers/DebugUsersController.cs
+++ b/src/Controllers/DebugUsersController.cs
@@ -1,14 +1,10 @@
 #nullable enable
-using System.Text.Json;
 
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 
-using Altinn.Platform.Storage.Repository;
 
 using LocalTest.Configuration;
-using LocalTest.Models;
-using LocalTest.Services.LocalApp.Interface;
 
 using LocalTest.Services.TestData;
 using Microsoft.AspNetCore.Authorization;
@@ -18,57 +14,52 @@ namespace LocalTest.Controllers;
 [Route("Home/[controller]/[action]")]
 public class DebugUsersController : Controller
 {
-    private readonly TenorDataRepository _tenorDataRepository;
     private readonly LocalPlatformSettings _localPlatformSettings;
-    private readonly ILocalApp _localApp;
+    private readonly TenorDataRepository _tenorDataRepository;
 
     public DebugUsersController(
-        TenorDataRepository tenorDataRepository,
         IOptions<LocalPlatformSettings> localPlatformSettings,
-        ILocalApp localApp)
+        TenorDataRepository tenorDataRepository)
     {
-        _tenorDataRepository = tenorDataRepository;
         _localPlatformSettings = localPlatformSettings.Value;
-        _localApp = localApp;
+        _tenorDataRepository = tenorDataRepository;
     }
 
-        // Debugging endpoint
-        [AllowAnonymous]
-        public async Task<IActionResult> LocalTestUsersRaw()
-        {
-            var localData = await TestDataDiskReader.ReadFromDisk(_localPlatformSettings.LocalTestingStaticTestDataPath);
+    // Debugging endpoint
+    [AllowAnonymous]
+    public async Task<IActionResult> LocalTestUsersRaw()
+    {
+        var localData = await TestDataDiskReader.ReadFromDisk(_localPlatformSettings.LocalTestingStaticTestDataPath);
 
-            return Json(localData);
-        }
+        return Json(localData);
+    }
 
-        //Debugging endpoint
-        [AllowAnonymous]
-        public async Task<IActionResult> LocalTestUsers()
-        {
-            var localData = await TestDataDiskReader.ReadFromDisk(_localPlatformSettings.LocalTestingStaticTestDataPath);
-            var constructedAppData = AppTestDataModel.FromTestDataModel(localData);
+    //Debugging endpoint
+    [AllowAnonymous]
+    public async Task<IActionResult> LocalTestUsers()
+    {
+        var localData = await TestDataDiskReader.ReadFromDisk(_localPlatformSettings.LocalTestingStaticTestDataPath);
+        var constructedAppData = AppTestDataModel.FromTestDataModel(localData);
 
-            return Json(constructedAppData);
-        }
+        return Json(constructedAppData);
+    }
 
-        // Debugging endpoint
-        [AllowAnonymous]
-        public async Task<IActionResult> LocalTestUsersRoundTrip()
-        {
-            var localData = await TestDataDiskReader.ReadFromDisk(_localPlatformSettings.LocalTestingStaticTestDataPath);
-            var constructedAppData = AppTestDataModel.FromTestDataModel(localData);
+    // Debugging endpoint
+    [AllowAnonymous]
+    public async Task<IActionResult> LocalTestUsersRoundTrip()
+    {
+        var localData = await TestDataDiskReader.ReadFromDisk(_localPlatformSettings.LocalTestingStaticTestDataPath);
+        var constructedAppData = AppTestDataModel.FromTestDataModel(localData);
 
-            return Json(constructedAppData.GetTestDataModel());
-        }
+        return Json(constructedAppData.GetTestDataModel());
+    }
 
-        // Debugging endpoint
-        [AllowAnonymous]
-        public async Task<IActionResult> ShowTenorUsers([FromServices] TenorDataRepository tenorDataRepository)
-        {
-            var localData = await tenorDataRepository.GetAppTestDataModel();
+    // Debugging endpoint
+    [AllowAnonymous]
+    public async Task<IActionResult> ShowTenorUsers()
+    {
+        var localData = await _tenorDataRepository.GetAppTestDataModel();
 
-            return Json(localData);
-        }
-
-
+        return Json(localData);
+    }
 }

--- a/src/Controllers/FrontendVersionController.cs
+++ b/src/Controllers/FrontendVersionController.cs
@@ -1,0 +1,103 @@
+#nullable enable
+using System.Text.Json;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+using Altinn.Platform.Storage.Repository;
+
+using LocalTest.Configuration;
+using LocalTest.Models;
+using LocalTest.Services.LocalApp.Interface;
+
+using LocalTest.Services.TestData;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace LocalTest.Controllers;
+
+[Route("Home/[controller]/[action]")]
+public class FrontendVersionController : Controller
+{
+    private readonly TenorDataRepository _tenorDataRepository;
+    private readonly LocalPlatformSettings _localPlatformSettings;
+    private readonly ILocalApp _localApp;
+
+    public FrontendVersionController(
+        TenorDataRepository tenorDataRepository,
+        IOptions<LocalPlatformSettings> localPlatformSettings,
+        ILocalApp localApp)
+    {
+        _tenorDataRepository = tenorDataRepository;
+        _localPlatformSettings = localPlatformSettings.Value;
+        _localApp = localApp;
+    }
+    /// <summary>
+    ///  See src\development\loadbalancer\nginx.conf
+    /// </summary>
+    public static readonly string FRONTEND_URL_COOKIE_NAME = "frontendVersion";
+
+    [HttpGet]
+    public async Task<ActionResult> Index([FromServices] HttpClient client)
+    {
+        var versionFromCookie = HttpContext.Request.Cookies[FRONTEND_URL_COOKIE_NAME];
+
+        var frontendVersion = new FrontendVersion()
+        {
+            Version = versionFromCookie,
+            Versions = new List<SelectListItem>()
+                {
+                    new ()
+                    {
+                        Text = "Keep as is",
+                        Value = "",
+                    },
+                    new ()
+                    {
+                        Text = "localhost:8080 (local dev)",
+                        Value = "http://localhost:8080/"
+                    }
+                }
+        };
+        var cdnVersionsString = await client.GetStringAsync("https://altinncdn.no/toolkits/altinn-app-frontend/index.json");
+        var groupCdnVersions = new SelectListGroup() { Name = "Specific version from cdn" };
+        var versions = JsonSerializer.Deserialize<List<string>>(cdnVersionsString)!;
+        versions.Reverse();
+        versions.ForEach(version =>
+        {
+            frontendVersion.Versions.Add(new()
+            {
+                Text = version,
+                Value = $"https://altinncdn.no/toolkits/altinn-app-frontend/{version}/",
+                Group = groupCdnVersions
+            });
+        });
+
+        return View(frontendVersion);
+    }
+    public ActionResult Index(FrontendVersion frontendVersion)
+    {
+        var options = new CookieOptions
+        {
+            Expires = DateTime.MaxValue,
+            HttpOnly = true,
+        };
+        ICookieManager cookieManager = new ChunkingCookieManager();
+        if (string.IsNullOrWhiteSpace(frontendVersion.Version))
+        {
+            cookieManager.DeleteCookie(HttpContext, FRONTEND_URL_COOKIE_NAME, options);
+        }
+        else
+        {
+            cookieManager.AppendResponseCookie(
+                HttpContext,
+                FRONTEND_URL_COOKIE_NAME,
+                frontendVersion.Version,
+                options
+                );
+        }
+
+        return RedirectToAction("Index", "Home");
+    }
+}

--- a/src/Controllers/FrontendVersionController.cs
+++ b/src/Controllers/FrontendVersionController.cs
@@ -4,14 +4,11 @@ using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 
-using Altinn.Platform.Storage.Repository;
-
 using LocalTest.Configuration;
 using LocalTest.Models;
 using LocalTest.Services.LocalApp.Interface;
 
 using LocalTest.Services.TestData;
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Mvc.Rendering;
 
@@ -20,19 +17,6 @@ namespace LocalTest.Controllers;
 [Route("Home/[controller]/[action]")]
 public class FrontendVersionController : Controller
 {
-    private readonly TenorDataRepository _tenorDataRepository;
-    private readonly LocalPlatformSettings _localPlatformSettings;
-    private readonly ILocalApp _localApp;
-
-    public FrontendVersionController(
-        TenorDataRepository tenorDataRepository,
-        IOptions<LocalPlatformSettings> localPlatformSettings,
-        ILocalApp localApp)
-    {
-        _tenorDataRepository = tenorDataRepository;
-        _localPlatformSettings = localPlatformSettings.Value;
-        _localApp = localApp;
-    }
     /// <summary>
     ///  See src\development\loadbalancer\nginx.conf
     /// </summary>

--- a/src/Controllers/HomeController.cs
+++ b/src/Controllers/HomeController.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Text.Json;
 using System.Xml;
 
 using Microsoft.AspNetCore.Authentication;

--- a/src/Controllers/HomeController.cs
+++ b/src/Controllers/HomeController.cs
@@ -24,6 +24,7 @@ using LocalTest.Services.TestData;
 
 namespace LocalTest.Controllers
 {
+    [Route("/Home/[action]")]
     public class HomeController : Controller
     {
         private readonly GeneralSettings _generalSettings;
@@ -32,7 +33,7 @@ namespace LocalTest.Controllers
         private readonly IAuthentication _authenticationService;
         private readonly IApplicationRepository _applicationRepository;
         private readonly IParties _partiesService;
-        private readonly IClaims _claimsService;
+
         private readonly ILocalApp _localApp;
         private readonly TestDataService _testDataService;
 
@@ -43,7 +44,6 @@ namespace LocalTest.Controllers
             IAuthentication authenticationService,
             IApplicationRepository applicationRepository,
             IParties partiesService,
-            IClaims claimsService,
             ILocalApp localApp,
             TestDataService testDataService)
         {
@@ -53,40 +53,14 @@ namespace LocalTest.Controllers
             _authenticationService = authenticationService;
             _applicationRepository = applicationRepository;
             _partiesService = partiesService;
-            _claimsService = claimsService;
             _localApp = localApp;
             _testDataService = testDataService;
         }
 
         [AllowAnonymous]
-        public async Task<IActionResult> LocalTestUsersRaw()
-        {
-            var localData = await TestDataDiskReader.ReadFromDisk(_localPlatformSettings.LocalTestingStaticTestDataPath);
-
-            return Json(localData);
-        }
-
-        //Debugging endpoint
-        [AllowAnonymous]
-        public async Task<IActionResult> LocalTestUsers()
-        {
-            var localData = await TestDataDiskReader.ReadFromDisk(_localPlatformSettings.LocalTestingStaticTestDataPath);
-            var constructedAppData = AppTestDataModel.FromTestDataModel(localData);
-
-            return Json(constructedAppData);
-        }
-
-        // Debugging endpoint
-        [AllowAnonymous]
-        public async Task<IActionResult> LocalTestUsersRoundTrip()
-        {
-            var localData = await TestDataDiskReader.ReadFromDisk(_localPlatformSettings.LocalTestingStaticTestDataPath);
-            var constructedAppData = AppTestDataModel.FromTestDataModel(localData);
-
-            return Json(constructedAppData.GetTestDataModel());
-        }
-
-        [AllowAnonymous]
+        [HttpGet("/")]
+        [HttpGet("/Home")]
+        [HttpGet("/Home/Index")]
         public async Task<IActionResult> Index()
         {
             StartAppModel model = new StartAppModel()
@@ -95,7 +69,7 @@ namespace LocalTest.Controllers
                 AppPath = _localPlatformSettings.AppRepositoryBasePath,
                 StaticTestDataPath = _localPlatformSettings.LocalTestingStaticTestDataPath,
                 LocalAppUrl = _localPlatformSettings.LocalAppUrl,
-                LocalFrontendUrl = HttpContext.Request.Cookies[FRONTEND_URL_COOKIE_NAME],
+                LocalFrontendUrl = HttpContext.Request.Cookies[FrontendVersionController.FRONTEND_URL_COOKIE_NAME],
             };
 
             try
@@ -232,76 +206,6 @@ namespace LocalTest.Controllers
             string token = await _authenticationService.GenerateTokenForOrg(id, orgNumber);
 
             return Ok(token);
-        }
-
-        /// <summary>
-        ///  See src\development\loadbalancer\nginx.conf
-        /// </summary>
-        public static readonly string FRONTEND_URL_COOKIE_NAME = "frontendVersion";
-
-        [HttpGet]
-        public async Task<ActionResult> FrontendVersion([FromServices] HttpClient client)
-        {
-            var versionFromCookie = HttpContext.Request.Cookies[FRONTEND_URL_COOKIE_NAME];
-
-
-
-            var frontendVersion = new FrontendVersion()
-            {
-                Version = versionFromCookie,
-                Versions = new List<SelectListItem>()
-                {
-                    new ()
-                    {
-                        Text = "Keep as is",
-                        Value = "",
-                    },
-                    new ()
-                    {
-                        Text = "localhost:8080 (local dev)",
-                        Value = "http://localhost:8080/"
-                    }
-                }
-            };
-            var cdnVersionsString = await client.GetStringAsync("https://altinncdn.no/toolkits/altinn-app-frontend/index.json");
-            var groupCdnVersions = new SelectListGroup() { Name = "Specific version from cdn" };
-            var versions = JsonSerializer.Deserialize<List<string>>(cdnVersionsString);
-            versions.Reverse();
-            versions.ForEach(version =>
-            {
-                frontendVersion.Versions.Add(new()
-                {
-                    Text = version,
-                    Value = $"https://altinncdn.no/toolkits/altinn-app-frontend/{version}/",
-                    Group = groupCdnVersions
-                });
-            });
-
-            return View(frontendVersion);
-        }
-        public ActionResult FrontendVersion(FrontendVersion frontendVersion)
-        {
-            var options = new CookieOptions
-            {
-                Expires = DateTime.MaxValue,
-                HttpOnly = true,
-            };
-            ICookieManager cookieManager = new ChunkingCookieManager();
-            if (string.IsNullOrWhiteSpace(frontendVersion.Version))
-            {
-                cookieManager.DeleteCookie(HttpContext, FRONTEND_URL_COOKIE_NAME, options);
-            }
-            else
-            {
-                cookieManager.AppendResponseCookie(
-                    HttpContext,
-                    FRONTEND_URL_COOKIE_NAME,
-                    frontendVersion.Version,
-                    options
-                    );
-            }
-
-            return RedirectToAction("Index");
         }
 
         private async Task<IEnumerable<SelectListItem>> GetTestUsersForList()

--- a/src/Controllers/StorageExplorerController.cs
+++ b/src/Controllers/StorageExplorerController.cs
@@ -1,0 +1,39 @@
+#nullable enable
+using System.Text.Json;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+using Altinn.Platform.Storage.Repository;
+
+using LocalTest.Configuration;
+using LocalTest.Models;
+using LocalTest.Services.LocalApp.Interface;
+
+using LocalTest.Services.TestData;
+using Microsoft.AspNetCore.Authorization;
+
+namespace LocalTest.Controllers;
+
+[Route("Home/[controller]/[action]")]
+public class StorageExplorerController : Controller
+{
+    private readonly TenorDataRepository _tenorDataRepository;
+    private readonly LocalPlatformSettings _localPlatformSettings;
+    private readonly ILocalApp _localApp;
+
+    public StorageExplorerController(
+        TenorDataRepository tenorDataRepository,
+        IOptions<LocalPlatformSettings> localPlatformSettings,
+        ILocalApp localApp)
+    {
+        _tenorDataRepository = tenorDataRepository;
+        _localPlatformSettings = localPlatformSettings.Value;
+        _localApp = localApp;
+    }
+
+    public IActionResult Index()
+    {
+        return View();
+    }
+}

--- a/src/Controllers/StorageExplorerController.cs
+++ b/src/Controllers/StorageExplorerController.cs
@@ -1,37 +1,12 @@
 #nullable enable
-using System.Text.Json;
 
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
-
-using Altinn.Platform.Storage.Repository;
-
-using LocalTest.Configuration;
-using LocalTest.Models;
-using LocalTest.Services.LocalApp.Interface;
-
-using LocalTest.Services.TestData;
-using Microsoft.AspNetCore.Authorization;
 
 namespace LocalTest.Controllers;
 
 [Route("Home/[controller]/[action]")]
 public class StorageExplorerController : Controller
 {
-    private readonly TenorDataRepository _tenorDataRepository;
-    private readonly LocalPlatformSettings _localPlatformSettings;
-    private readonly ILocalApp _localApp;
-
-    public StorageExplorerController(
-        TenorDataRepository tenorDataRepository,
-        IOptions<LocalPlatformSettings> localPlatformSettings,
-        ILocalApp localApp)
-    {
-        _tenorDataRepository = tenorDataRepository;
-        _localPlatformSettings = localPlatformSettings.Value;
-        _localApp = localApp;
-    }
-
     public IActionResult Index()
     {
         return View();

--- a/src/Controllers/TenorUsersController.cs
+++ b/src/Controllers/TenorUsersController.cs
@@ -2,11 +2,6 @@
 using System.Text.Json;
 
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
-
-using Altinn.Platform.Storage.Repository;
-
-using LocalTest.Configuration;
 using LocalTest.Models;
 using LocalTest.Services.LocalApp.Interface;
 
@@ -18,27 +13,19 @@ namespace LocalTest.Controllers;
 public class TenorUsersController : Controller
 {
     private readonly TenorDataRepository _tenorDataRepository;
-    private readonly ILocalApp _localApp;
 
-    public TenorUsersController(
-        TenorDataRepository tenorDataRepository,
-        ILocalApp localApp)
+    public TenorUsersController(TenorDataRepository tenorDataRepository)
     {
         _tenorDataRepository = tenorDataRepository;
-        _localApp = localApp;
     }
 
 
 
     public async Task<IActionResult> Index()
     {
-        var appUsers = await _localApp.GetTestData();
-
         return View(new TenorViewModel()
         {
-            AppUsers = appUsers,
             FileItems = await _tenorDataRepository.GetFileItems(),
-
         });
     }
 

--- a/src/Controllers/TenorUsersController.cs
+++ b/src/Controllers/TenorUsersController.cs
@@ -1,0 +1,86 @@
+#nullable enable
+using System.Text.Json;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+
+using Altinn.Platform.Storage.Repository;
+
+using LocalTest.Configuration;
+using LocalTest.Models;
+using LocalTest.Services.LocalApp.Interface;
+
+using LocalTest.Services.TestData;
+
+namespace LocalTest.Controllers;
+
+[Route("Home/[controller]/[action]")]
+public class TenorUsersController : Controller
+{
+    private readonly TenorDataRepository _tenorDataRepository;
+    private readonly ILocalApp _localApp;
+
+    public TenorUsersController(
+        TenorDataRepository tenorDataRepository,
+        ILocalApp localApp)
+    {
+        _tenorDataRepository = tenorDataRepository;
+        _localApp = localApp;
+    }
+
+
+
+    public async Task<IActionResult> Index()
+    {
+        var appUsers = await _localApp.GetTestData();
+
+        return View(new TenorViewModel()
+        {
+            AppUsers = appUsers,
+            FileItems = await _tenorDataRepository.GetFileItems(),
+
+        });
+    }
+
+
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Upload()
+    {
+        //TODO: validate uploaded files
+        foreach (var file in Request.Form.Files)
+        {
+            await _tenorDataRepository.StoreUploadedFile(file);
+        }
+        return RedirectToAction("Index");
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Update()
+    {
+        var files = Request.Form.Keys.Where(k => k.EndsWith(".json")).ToList();
+        if (Request.Form.ContainsKey("Download"))
+        {
+            return Json(await _tenorDataRepository.GetAppTestDataModel(files));
+        }
+        else if (Request.Form.ContainsKey("DownloadFile"))
+        {
+            return File(JsonSerializer.SerializeToUtf8Bytes(await _tenorDataRepository.GetAppTestDataModel(files)), "application/json", "testData.json");
+        }
+        else if (Request.Form.ContainsKey("Delete"))
+        {
+            foreach (var file in files)
+            {
+                _tenorDataRepository.DeleteFile(file);
+            }
+
+            return RedirectToAction("Index");
+        }
+        else
+        {
+            throw new Exception("Unknown action");
+        }
+    }
+}

--- a/src/Models/Authentication/CustomClaim.cs
+++ b/src/Models/Authentication/CustomClaim.cs
@@ -1,21 +1,26 @@
-﻿namespace Altinn.Platform.Authentication.Model
+﻿using System.Text.Json.Serialization;
+
+namespace Altinn.Platform.Authentication.Model
 {
     public class CustomClaim
     {
         /// <summary>
         /// Gets or sets the claim type, E.g. custom:claim
         /// </summary>
+        [JsonPropertyName("type")]
         public string Type { get; set; }
 
         /// <summary>
         /// Gets or sets the claim value, E.g. customValue
         /// </summary>
+        [JsonPropertyName("value")]
         public string Value { get; set; }
 
         /// <summary>
         /// Gets or sets the value type for the claim, E.g. http://www.w3.org/2001/XMLSchema#string
         /// See System.Security.Claims.ClaimValueTypes for more value types
         /// </summary>
+        [JsonPropertyName("valueType")]
         public string ValueType { get; set; }
     }
 }

--- a/src/Models/Authorization/Role.cs
+++ b/src/Models/Authorization/Role.cs
@@ -13,7 +13,7 @@ namespace Authorization.Interface.Models
         /// Gets or sets the role type
         /// </summary>
         [JsonProperty]
-        [JsonPropertyName("value")]
+        [JsonPropertyName("type")]
         public string Type { get; set; }
 
         /// <summary>

--- a/src/Models/Authorization/Role.cs
+++ b/src/Models/Authorization/Role.cs
@@ -1,7 +1,5 @@
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Text.Json.Serialization;
 
 namespace Authorization.Interface.Models
 {
@@ -15,12 +13,14 @@ namespace Authorization.Interface.Models
         /// Gets or sets the role type
         /// </summary>
         [JsonProperty]
+        [JsonPropertyName("value")]
         public string Type { get; set; }
 
         /// <summary>
         /// Gets or sets the role
         /// </summary>
         [JsonProperty]
+        [JsonPropertyName("value")]
         public string Value { get; set; }
     }
 }

--- a/src/Models/TenorViewModel.cs
+++ b/src/Models/TenorViewModel.cs
@@ -7,7 +7,6 @@ using LocalTest.Services.TestData;
 public class TenorViewModel
 {
     public List<TenorFileItem> FileItems { get; set; } = default!;
-    public AppTestDataModel? AppUsers { get; set; }
 }
 
 public class TenorFileItem

--- a/src/Models/TenorViewModel.cs
+++ b/src/Models/TenorViewModel.cs
@@ -14,6 +14,7 @@ public class TenorFileItem
 {
     public string FileName { get; set; } = default!;
     public string RawFileContent { get; set; } = default!;
+    public bool Valid => Freg is not null || Brreg is not null;
     public Freg? Freg { get; set; }
     public BrregErFr? Brreg { get; set; }
 }

--- a/src/Models/TenorViewModel.cs
+++ b/src/Models/TenorViewModel.cs
@@ -1,0 +1,19 @@
+#nullable enable
+namespace LocalTest.Models;
+
+using LocalTest.Services.Tenor.Models;
+using LocalTest.Services.TestData;
+
+public class TenorViewModel
+{
+    public List<TenorFileItem> FileItems { get; set; } = default!;
+    public AppTestDataModel? AppUsers { get; set; }
+}
+
+public class TenorFileItem
+{
+    public string FileName { get; set; } = default!;
+    public string RawFileContent { get; set; } = default!;
+    public Freg? Freg { get; set; }
+    public BrregErFr? Brreg { get; set; }
+}

--- a/src/Services/Tenor/Models/BrregErFr.cs
+++ b/src/Services/Tenor/Models/BrregErFr.cs
@@ -1,0 +1,365 @@
+#nullable disable
+namespace LocalTest.Services.Tenor.Models;
+
+
+using System.Text.Json.Serialization;
+
+public class BrregErFr
+{
+    /// <summary>
+    /// Internally assigned property that is Altinn's inernal ID
+    /// </summary>
+    [JsonIgnore]
+    public int PartyId { get; set; }
+
+    [JsonPropertyName("organisasjonsnummer")]
+    public string Organisasjonsnummer { get; set; }
+
+    [JsonPropertyName("navn")]
+    public string Navn { get; set; }
+
+    [JsonPropertyName("oppdeltNavn")]
+    public List<string> OppdeltNavn { get; set; }
+
+    [JsonPropertyName("organisasjonsform")]
+    public Organisasjonsform Organisasjonsform { get; set; }
+
+    [JsonPropertyName("forretningsadresse")]
+    public Forretningsadresse Forretningsadresse { get; set; }
+
+    [JsonPropertyName("postadresse")]
+    public Postadresse Postadresse { get; set; }
+
+    [JsonPropertyName("naeringskoder")]
+    public List<Naeringskoder> Naeringskoder { get; set; }
+
+    [JsonPropertyName("institusjonellSektorkode")]
+    public InstitusjonellSektorkode InstitusjonellSektorkode { get; set; }
+
+    [JsonPropertyName("registreringsdatoEnhetsregisteret")]
+    public string RegistreringsdatoEnhetsregisteret { get; set; }
+
+    [JsonPropertyName("slettetIEnhetsregisteret")]
+    public string SlettetIEnhetsregisteret { get; set; }
+
+    [JsonPropertyName("registrertIForetaksregisteret")]
+    public string RegistrertIForetaksregisteret { get; set; }
+
+    [JsonPropertyName("registreringsdatoForetaksregisteret")]
+    public string RegistreringsdatoForetaksregisteret { get; set; }
+
+    [JsonPropertyName("slettetIForetaksregisteret")]
+    public string SlettetIForetaksregisteret { get; set; }
+
+    [JsonPropertyName("registreringspliktigForetaksregisteret")]
+    public string RegistreringspliktigForetaksregisteret { get; set; }
+
+    [JsonPropertyName("registrertIFrivillighetsregisteret")]
+    public string RegistrertIFrivillighetsregisteret { get; set; }
+
+    [JsonPropertyName("registrertIStiftelsesregisteret")]
+    public string RegistrertIStiftelsesregisteret { get; set; }
+
+    [JsonPropertyName("registrertIMvaregisteret")]
+    public string RegistrertIMvaregisteret { get; set; }
+
+    [JsonPropertyName("stiftelsesdato")]
+    public string Stiftelsesdato { get; set; }
+
+    [JsonPropertyName("aktivitetBransje")]
+    public List<string> AktivitetBransje { get; set; }
+
+    [JsonPropertyName("vedtektsdato")]
+    public string Vedtektsdato { get; set; }
+
+    [JsonPropertyName("vedtektsfestetFormaal")]
+    public List<string> VedtektsfestetFormaal { get; set; }
+
+    [JsonPropertyName("sisteInnsendteAarsregnskap")]
+    public string SisteInnsendteAarsregnskap { get; set; }
+
+    [JsonPropertyName("konkurs")]
+    public string Konkurs { get; set; }
+
+    [JsonPropertyName("underAvvikling")]
+    public string UnderAvvikling { get; set; }
+
+    [JsonPropertyName("underTvangsavviklingEllerTvangsopplosning")]
+    public string UnderTvangsavviklingEllerTvangsopplosning { get; set; }
+
+    [JsonPropertyName("maalform")]
+    public string Maalform { get; set; }
+
+    [JsonPropertyName("ansvarsbegrensning")]
+    public string Ansvarsbegrensning { get; set; }
+
+    [JsonPropertyName("harAnsatte")]
+    public string HarAnsatte { get; set; }
+
+    [JsonPropertyName("antallAnsatte")]
+    public int? AntallAnsatte { get; set; }
+
+    [JsonPropertyName("underenhet")]
+    public Underenhet Underenhet { get; set; }
+
+    [JsonPropertyName("bedriftsforsamling")]
+    public string Bedriftsforsamling { get; set; }
+
+    [JsonPropertyName("representantskap")]
+    public string Representantskap { get; set; }
+
+    [JsonPropertyName("enhetstatuser")]
+    public List<object> Enhetstatuser { get; set; }
+
+    [JsonPropertyName("fullmakter")]
+    public List<object> Fullmakter { get; set; }
+
+    [JsonPropertyName("frivilligMvaRegistrert")]
+    public List<object> FrivilligMvaRegistrert { get; set; }
+
+    [JsonPropertyName("finansielleInstrumenter")]
+    public List<object> FinansielleInstrumenter { get; set; }
+
+    [JsonPropertyName("kapital")]
+    public Kapital Kapital { get; set; }
+
+    [JsonPropertyName("kjonnsrepresentasjon")]
+    public string Kjonnsrepresentasjon { get; set; }
+
+    [JsonPropertyName("matrikkelnummer")]
+    public List<object> Matrikkelnummer { get; set; }
+
+    [JsonPropertyName("paategninger")]
+    public List<object> Paategninger { get; set; }
+
+    [JsonPropertyName("fravalgAvRevisjon")]
+    public FravalgAvRevisjon FravalgAvRevisjon { get; set; }
+
+    [JsonPropertyName("norskregistrertUtenlandskForetak")]
+    public NorskregistrertUtenlandskForetak NorskregistrertUtenlandskForetak { get; set; }
+
+    [JsonPropertyName("lovgivningOgForetaksformIHjemlandet")]
+    public LovgivningOgForetaksformIHjemlandet LovgivningOgForetaksformIHjemlandet { get; set; }
+
+    [JsonPropertyName("registerIHjemlandet")]
+    public RegisterIHjemlandet RegisterIHjemlandet { get; set; }
+
+    [JsonPropertyName("fusjoner")]
+    public List<object> Fusjoner { get; set; }
+
+    [JsonPropertyName("fisjoner")]
+    public List<object> Fisjoner { get; set; }
+
+    [JsonPropertyName("rollegrupper")]
+    public List<Rollegrupper> Rollegrupper { get; set; }
+}
+
+public class Forretningsadresse
+{
+    [JsonPropertyName("land")]
+    public string Land { get; set; }
+
+    [JsonPropertyName("landkode")]
+    public string Landkode { get; set; }
+
+    [JsonPropertyName("postnummer")]
+    public string Postnummer { get; set; }
+
+    [JsonPropertyName("poststed")]
+    public string Poststed { get; set; }
+
+    [JsonPropertyName("adresse")]
+    public List<string> Adresse { get; set; }
+
+    [JsonPropertyName("kommune")]
+    public string Kommune { get; set; }
+
+    [JsonPropertyName("kommunenummer")]
+    public string Kommunenummer { get; set; }
+}
+
+public class FravalgAvRevisjon
+{
+    [JsonPropertyName("fravalg")]
+    public string Fravalg { get; set; }
+}
+
+public class Fritekst
+{
+    [JsonPropertyName("plassering")]
+    public string Plassering { get; set; }
+}
+
+public class InstitusjonellSektorkode
+{
+    [JsonPropertyName("kode")]
+    public string Kode { get; set; }
+
+    [JsonPropertyName("beskrivelse")]
+    public string Beskrivelse { get; set; }
+}
+
+public class Kapital
+{
+    [JsonPropertyName("type")]
+    public string Type { get; set; }
+
+    [JsonPropertyName("belop")]
+    public string Belop { get; set; }
+
+    [JsonPropertyName("antallAksjer")]
+    public string AntallAksjer { get; set; }
+
+    [JsonPropertyName("innbetaltBelop")]
+    public string InnbetaltBelop { get; set; }
+
+    [JsonPropertyName("fritekst")]
+    public List<object> Fritekst { get; set; }
+
+    [JsonPropertyName("fulltInnbetaltBelop")]
+    public string FulltInnbetaltBelop { get; set; }
+
+    [JsonPropertyName("sakkyndigRedegjorelse")]
+    public string SakkyndigRedegjorelse { get; set; }
+}
+
+public class LovgivningOgForetaksformIHjemlandet
+{
+    [JsonPropertyName("foretaksform")]
+    public string Foretaksform { get; set; }
+}
+
+public class Naeringskoder
+{
+    [JsonPropertyName("kode")]
+    public string Kode { get; set; }
+
+    [JsonPropertyName("beskrivelse")]
+    public string Beskrivelse { get; set; }
+
+    [JsonPropertyName("hjelpeenhetskode")]
+    public bool? Hjelpeenhetskode { get; set; }
+
+    [JsonPropertyName("rekkefolge")]
+    public int? Rekkefolge { get; set; }
+
+    [JsonPropertyName("nivaa")]
+    public int? Nivaa { get; set; }
+}
+
+public class NorskregistrertUtenlandskForetak
+{
+    [JsonPropertyName("helNorskEierskap")]
+    public string HelNorskEierskap { get; set; }
+
+    [JsonPropertyName("aktivitetINorge")]
+    public string AktivitetINorge { get; set; }
+}
+
+public class Organisasjonsform
+{
+    [JsonPropertyName("kode")]
+    public string Kode { get; set; }
+
+    [JsonPropertyName("beskrivelse")]
+    public string Beskrivelse { get; set; }
+}
+
+public class Person
+{
+    [JsonPropertyName("foedselsnummer")]
+    public string Foedselsnummer { get; set; }
+}
+
+public class Postadresse
+{
+    [JsonPropertyName("land")]
+    public string Land { get; set; }
+
+    [JsonPropertyName("landkode")]
+    public string Landkode { get; set; }
+
+    [JsonPropertyName("postnummer")]
+    public string Postnummer { get; set; }
+
+    [JsonPropertyName("poststed")]
+    public string Poststed { get; set; }
+
+    [JsonPropertyName("adresse")]
+    public List<string> Adresse { get; set; }
+
+    [JsonPropertyName("kommune")]
+    public string Kommune { get; set; }
+
+    [JsonPropertyName("kommunenummer")]
+    public string Kommunenummer { get; set; }
+}
+
+public class RegisterIHjemlandet
+{
+    [JsonPropertyName("navnRegister")]
+    public List<object> NavnRegister { get; set; }
+
+    [JsonPropertyName("adresse")]
+    public List<object> Adresse { get; set; }
+}
+
+public class Rollegrupper
+{
+    [JsonPropertyName("type")]
+    public Type Type { get; set; }
+
+    [JsonPropertyName("fritekst")]
+    public List<Fritekst> Fritekst { get; set; }
+
+    [JsonPropertyName("roller")]
+    public List<Roller> Roller { get; set; }
+}
+
+public class Roller
+{
+    [JsonPropertyName("type")]
+    public Type Type { get; set; }
+
+    [JsonPropertyName("person")]
+    public Person Person { get; set; }
+
+    [JsonPropertyName("virksomhet")]
+    public Virksomhet Virksomhet { get; set; }
+
+    [JsonPropertyName("valgtAv")]
+    public ValgtAv ValgtAv { get; set; }
+
+    [JsonPropertyName("fratraadt")]
+    public string Fratraadt { get; set; }
+
+    [JsonPropertyName("fritekst")]
+    public List<object> Fritekst { get; set; }
+
+    [JsonPropertyName("rekkefolge")]
+    public int? Rekkefolge { get; set; }
+}
+
+
+
+public class Type
+{
+    [JsonPropertyName("kode")]
+    public string Kode { get; set; }
+
+    [JsonPropertyName("beskrivelse")]
+    public string Beskrivelse { get; set; }
+}
+
+public class Underenhet
+{
+}
+
+public class ValgtAv
+{
+}
+
+public class Virksomhet
+{
+}
+

--- a/src/Services/Tenor/Models/Freg.cs
+++ b/src/Services/Tenor/Models/Freg.cs
@@ -1,0 +1,342 @@
+#nullable disable
+namespace LocalTest.Services.Tenor.Models;
+
+using System.Text.Json.Serialization;
+
+public class Freg
+{
+    /// <summary>
+    /// Internally assigned property that is Altinn's inernal ID
+    /// </summary>
+    [JsonIgnore]
+    public int PartyId { get; set; }
+
+    [JsonPropertyName("identifikasjonsnummer")]
+    public List<Identifikasjonsnummer> Identifikasjonsnummer { get; set; }
+
+    [JsonPropertyName("status")]
+    public List<StatusType> Status { get; set; }
+
+    [JsonPropertyName("kjoenn")]
+    public List<KjoennType> Kjoenn { get; set; }
+
+    [JsonPropertyName("foedsel")]
+    public List<Foedsel> Foedsel { get; set; }
+
+    [JsonPropertyName("foedselINorge")]
+    public List<FoedselINorge> FoedselINorge { get; set; }
+
+    [JsonPropertyName("familierelasjon")]
+    public List<Familierelasjon> Familierelasjon { get; set; }
+
+    [JsonPropertyName("sivilstand")]
+    public List<SivilstandType> Sivilstand { get; set; }
+
+    [JsonPropertyName("navn")]
+    public List<Navn> Navn { get; set; }
+
+    [JsonPropertyName("bostedsadresse")]
+    public List<Bostedsadresse> Bostedsadresse { get; set; }
+
+    [JsonPropertyName("statsborgerskap")]
+    public List<StatsborgerskapType> Statsborgerskap { get; set; }
+}
+
+public class Adressenummer
+{
+    [JsonPropertyName("husnummer")]
+    public string Husnummer { get; set; }
+}
+
+public class Bostedsadresse
+{
+    [JsonPropertyName("ajourholdstidspunkt")]
+    public DateTime? Ajourholdstidspunkt { get; set; }
+
+    [JsonPropertyName("erGjeldende")]
+    public bool? ErGjeldende { get; set; }
+
+    [JsonPropertyName("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonPropertyName("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonPropertyName("gyldighetstidspunkt")]
+    public DateTime? Gyldighetstidspunkt { get; set; }
+
+    [JsonPropertyName("vegadresse")]
+    public Vegadresse Vegadresse { get; set; }
+
+    [JsonPropertyName("adresseIdentifikatorFraMatrikkelen")]
+    public string AdresseIdentifikatorFraMatrikkelen { get; set; }
+
+    [JsonPropertyName("adressegradering")]
+    public string Adressegradering { get; set; }
+
+    [JsonPropertyName("flyttedato")]
+    public string Flyttedato { get; set; }
+
+    [JsonPropertyName("grunnkrets")]
+    public int? Grunnkrets { get; set; }
+
+    [JsonPropertyName("stemmekrets")]
+    public int? Stemmekrets { get; set; }
+
+    [JsonPropertyName("skolekrets")]
+    public int? Skolekrets { get; set; }
+
+    [JsonPropertyName("kirkekrets")]
+    public int? Kirkekrets { get; set; }
+}
+
+public class Familierelasjon
+{
+    [JsonPropertyName("ajourholdstidspunkt")]
+    public DateTime? Ajourholdstidspunkt { get; set; }
+
+    [JsonPropertyName("erGjeldende")]
+    public bool? ErGjeldende { get; set; }
+
+    [JsonPropertyName("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonPropertyName("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonPropertyName("gyldighetstidspunkt")]
+    public DateTime? Gyldighetstidspunkt { get; set; }
+
+    [JsonPropertyName("relatertPerson")]
+    public string RelatertPerson { get; set; }
+
+    [JsonPropertyName("relatertPersonsRolle")]
+    public string RelatertPersonsRolle { get; set; }
+
+    [JsonPropertyName("minRolleForPerson")]
+    public string MinRolleForPerson { get; set; }
+}
+
+public class Foedsel
+{
+    [JsonPropertyName("ajourholdstidspunkt")]
+    public DateTime? Ajourholdstidspunkt { get; set; }
+
+    [JsonPropertyName("erGjeldende")]
+    public bool? ErGjeldende { get; set; }
+
+    [JsonPropertyName("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonPropertyName("gyldighetstidspunkt")]
+    public DateTime? Gyldighetstidspunkt { get; set; }
+
+    [JsonPropertyName("foedselsdato")]
+    public string Foedselsdato { get; set; }
+
+    [JsonPropertyName("foedselsaar")]
+    public string Foedselsaar { get; set; }
+
+    [JsonPropertyName("foedekommuneINorge")]
+    public string FoedekommuneINorge { get; set; }
+
+    [JsonPropertyName("foedeland")]
+    public string Foedeland { get; set; }
+}
+
+public class FoedselINorge
+{
+    [JsonPropertyName("ajourholdstidspunkt")]
+    public DateTime? Ajourholdstidspunkt { get; set; }
+
+    [JsonPropertyName("erGjeldende")]
+    public bool? ErGjeldende { get; set; }
+
+    [JsonPropertyName("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonPropertyName("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonPropertyName("gyldighetstidspunkt")]
+    public DateTime? Gyldighetstidspunkt { get; set; }
+
+    [JsonPropertyName("foedselsinstitusjonsnavn")]
+    public string Foedselsinstitusjonsnavn { get; set; }
+
+    [JsonPropertyName("rekkefoelgenummer")]
+    public int? Rekkefoelgenummer { get; set; }
+}
+
+public class Identifikasjonsnummer
+{
+    [JsonPropertyName("ajourholdstidspunkt")]
+    public DateTime? Ajourholdstidspunkt { get; set; }
+
+    [JsonPropertyName("erGjeldende")]
+    public bool? ErGjeldende { get; set; }
+
+    [JsonPropertyName("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonPropertyName("status")]
+    public string Status { get; set; }
+
+    [JsonPropertyName("foedselsEllerDNummer")]
+    public string FoedselsEllerDNummer { get; set; }
+
+    [JsonPropertyName("identifikatortype")]
+    public string Identifikatortype { get; set; }
+}
+
+public class KjoennType
+{
+    [JsonPropertyName("erGjeldende")]
+    public bool? ErGjeldende { get; set; }
+
+    [JsonPropertyName("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonPropertyName("kjoenn")]
+    public string Kjoenn { get; set; }
+}
+
+public class Navn
+{
+    [JsonPropertyName("ajourholdstidspunkt")]
+    public DateTime? Ajourholdstidspunkt { get; set; }
+
+    [JsonPropertyName("erGjeldende")]
+    public bool? ErGjeldende { get; set; }
+
+    [JsonPropertyName("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonPropertyName("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonPropertyName("gyldighetstidspunkt")]
+    public DateTime? Gyldighetstidspunkt { get; set; }
+
+    [JsonPropertyName("fornavn")]
+    public string Fornavn { get; set; }
+
+    [JsonPropertyName("mellomnavn")]
+    public string Mellomnavn { get; set; }
+
+    [JsonPropertyName("etternavn")]
+    public string Etternavn { get; set; }
+}
+
+public class Poststed
+{
+    [JsonPropertyName("poststedsnavn")]
+    public string Poststedsnavn { get; set; }
+
+    [JsonPropertyName("postnummer")]
+    public string Postnummer { get; set; }
+}
+
+
+public class SivilstandType
+{
+    [JsonPropertyName("ajourholdstidspunkt")]
+    public DateTime? Ajourholdstidspunkt { get; set; }
+
+    [JsonPropertyName("erGjeldende")]
+    public bool? ErGjeldende { get; set; }
+
+    [JsonPropertyName("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonPropertyName("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonPropertyName("gyldighetstidspunkt")]
+    public DateTime? Gyldighetstidspunkt { get; set; }
+
+    [JsonPropertyName("sivilstand")]
+    public string Sivilstand { get; set; }
+
+    [JsonPropertyName("sivilstandsdato")]
+    public string Sivilstandsdato { get; set; }
+
+    [JsonPropertyName("myndighet")]
+    public string Myndighet { get; set; }
+
+    [JsonPropertyName("kommune")]
+    public string Kommune { get; set; }
+
+    [JsonPropertyName("sted")]
+    public string Sted { get; set; }
+
+    [JsonPropertyName("relatertVedSivilstand")]
+    public string RelatertVedSivilstand { get; set; }
+}
+
+public class StatsborgerskapType
+{
+    [JsonPropertyName("ajourholdstidspunkt")]
+    public DateTime? Ajourholdstidspunkt { get; set; }
+
+    [JsonPropertyName("erGjeldende")]
+    public bool? ErGjeldende { get; set; }
+
+    [JsonPropertyName("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonPropertyName("aarsak")]
+    public string Aarsak { get; set; }
+
+    [JsonPropertyName("gyldighetstidspunkt")]
+    public DateTime? Gyldighetstidspunkt { get; set; }
+
+    [JsonPropertyName("statsborgerskap")]
+    public string Statsborgerskap { get; set; }
+
+    [JsonPropertyName("ervervsdato")]
+    public string Ervervsdato { get; set; }
+}
+
+public class StatusType
+{
+    [JsonPropertyName("ajourholdstidspunkt")]
+    public DateTime? Ajourholdstidspunkt { get; set; }
+
+    [JsonPropertyName("erGjeldende")]
+    public bool? ErGjeldende { get; set; }
+
+    [JsonPropertyName("kilde")]
+    public string Kilde { get; set; }
+
+    [JsonPropertyName("gyldighetstidspunkt")]
+    public DateTime? Gyldighetstidspunkt { get; set; }
+
+    [JsonPropertyName("status")]
+    public string Status { get; set; }
+}
+
+public class Vegadresse
+{
+    [JsonPropertyName("kommunenummer")]
+    public string Kommunenummer { get; set; }
+
+    [JsonPropertyName("bruksenhetsnummer")]
+    public string Bruksenhetsnummer { get; set; }
+
+    [JsonPropertyName("bruksenhetstype")]
+    public string Bruksenhetstype { get; set; }
+
+    [JsonPropertyName("adressenavn")]
+    public string Adressenavn { get; set; }
+
+    [JsonPropertyName("adressenummer")]
+    public Adressenummer Adressenummer { get; set; }
+
+    [JsonPropertyName("adressekode")]
+    public string Adressekode { get; set; }
+
+    [JsonPropertyName("poststed")]
+    public Poststed Poststed { get; set; }
+}
+

--- a/src/Services/Tenor/TenorDataReader.cs
+++ b/src/Services/Tenor/TenorDataReader.cs
@@ -1,0 +1,198 @@
+#nullable enable
+using System.Text.Json;
+using Authorization.Interface.Models;
+using LocalTest.Configuration;
+using LocalTest.Models;
+using LocalTest.Services.Tenor.Models;
+using Microsoft.Extensions.Options;
+
+namespace LocalTest.Services.TestData;
+
+public class TenorDataRepository
+{
+    private static readonly JsonSerializerOptions _options = new(JsonSerializerDefaults.Web)
+    {
+        Converters = { new System.Text.Json.Serialization.JsonStringEnumConverter() }
+    };
+    private readonly LocalPlatformSettings _settings;
+
+    public TenorDataRepository(IOptions<LocalPlatformSettings> settings)
+    {
+        _settings = settings.Value;
+    }
+
+    public DirectoryInfo GetTenorStorageDirectory()
+    {
+        return new DirectoryInfo(Path.Join(_settings.LocalTestingStorageBasePath, _settings.TenorDataFolder));
+    }
+
+
+    public async Task<(List<BrregErFr>, List<Freg>)> ReadFromDisk(List<string>? files = null)
+    {
+        var freg = new List<Freg>();
+        var brregErFr = new List<BrregErFr>();
+        var tenorFolder = GetTenorStorageDirectory();
+        if (!tenorFolder.Exists)
+        {
+            return (brregErFr, freg);
+        }
+
+        foreach (var fregFile in tenorFolder.GetFiles("freg.*.kildedata.json").Where(f => files?.Contains(f.Name) ?? true))
+        {
+            var fileBytes = await File.ReadAllBytesAsync(fregFile.FullName);
+            var fileData = JsonSerializer.Deserialize<Freg>(fileBytes, _options);
+            if (fileData is not null)
+                freg.Add(fileData);
+        }
+        foreach (var brregFile in tenorFolder.GetFiles("brreg-er-fr.*.kildedata.json").Where(f => files?.Contains(f.Name) ?? true))
+        {
+            var fileBytes = await File.ReadAllBytesAsync(brregFile.FullName);
+            var fileData = JsonSerializer.Deserialize<BrregErFr>(fileBytes, _options);
+            if (fileData is not null)
+                brregErFr.Add(fileData);
+        }
+
+        return (brregErFr, freg);
+    }
+
+    public async Task<AppTestDataModel> GetAppTestDataModel(List<string>? files = null)
+    {
+        var (brreg, freg) = await ReadFromDisk(files);
+        // Assign partyId to all entities
+        int partyId = 600000;
+        freg.ForEach(f => f.PartyId = partyId++);
+        partyId = 700000;
+        brreg.ForEach(b => b.PartyId = partyId++);
+
+
+        var roles = brreg.SelectMany(b => b.Rollegrupper.SelectMany(rg => rg.Roller.Select(r => (b.PartyId, r.Type.Kode, r.Person.Foedselsnummer)))).Where(r => r.Foedselsnummer is not null);
+        var fnrRoleLookup = roles.GroupBy(r => r.Foedselsnummer).ToDictionary(role => role.Key, role => role.GroupBy(r => r.PartyId).ToDictionary(k => k.Key, k => k.Select(tuple => new Role { Type = "Altinn", Value = tuple.Kode }).ToList()));
+
+
+        int userId = 10000;
+        return new()
+        {
+            Persons = freg.Select(f =>
+            {
+                var fnr = f.Identifikasjonsnummer.FirstErGjeldende()?.FoedselsEllerDNummer ?? throw new Exception("fødselsnummer ikke funnet");
+                var adresse = f.Bostedsadresse.FirstErGjeldende() ?? throw new Exception("Mangler bostedsadresse");
+                return new AppTestPerson
+                {
+                    UserId = userId++,
+                    PartyId = f.PartyId,
+                    SSN = fnr,
+                    FirstName = f.Navn.FirstErGjeldende()?.Fornavn ?? "Ukjent",
+                    LastName = f.Navn.FirstErGjeldende()?.Etternavn ?? "Ukjent",
+                    MiddleName = f.Navn.FirstErGjeldende()?.Mellomnavn,
+                    UserName = $"user-{99999999999 - long.Parse(fnr)}", // Make an sytnetic username based on an obfuscated fnr
+                    AddressCity = adresse.Vegadresse.Poststed.Poststedsnavn,
+                    // AddressMunicipalName = adresse.Vegadresse.Kommunenummer,
+                    AddressMunicipalNumber = adresse.Vegadresse.Kommunenummer,
+                    AddressHouseLetter = f.Bostedsadresse.FirstErGjeldende()?.Vegadresse.Adressekode,
+                    AddressHouseNumber = f.Bostedsadresse.FirstErGjeldende()?.Vegadresse.Adressenummer.Husnummer,
+                    AddressMunicipalName = null,
+                    AddressPostalCode = null,
+                    AddressStreetName = null,
+                    Email = null,
+                    MobileNumber = null,
+                    TelephoneNumber = null,
+                    Language = null,
+                    MailingAddress = null,
+                    MailingPostalCity = null,
+                    MailingPostalCode = null,
+                    PartyRoles = fnrRoleLookup.TryGetValue(fnr, out var partyRoles) ? partyRoles : new Dictionary<int, List<Role>>(),
+                    CustomClaims = new()
+                    {
+                        new()
+                        {
+                            Type = "user:source",
+                            ValueType = "http://www.w3.org/2001/XMLSchema#string",
+                            Value = "localTenor"
+                        }
+                    },
+
+                };
+            }).ToList(),
+            Orgs = brreg.Select(b => new AppTestOrg
+            {
+                PartyId = b.PartyId,
+                ParentPartyId = null,
+                OrgNumber = b.Organisasjonsnummer,
+                Name = b.Navn,
+                BusinessAddress = string.Join("\n", b.Forretningsadresse.Adresse),
+                BusinessPostalCity = b.Forretningsadresse.Poststed,
+                BusinessPostalCode = b.Forretningsadresse.Postnummer,
+                MailingAddress = string.Join("\n", b.Postadresse.Adresse),
+                MailingPostalCity = b.Postadresse.Poststed,
+                MailingPostalCode = b.Postadresse.Postnummer,
+                EMailAddress = null,
+                FaxNumber = null,
+                InternetAddress = null,
+                MobileNumber = null,
+                TelephoneNumber = null,
+                UnitStatus = null,
+                UnitType = null,
+            }).ToList(),
+        };
+    }
+
+    public async Task StoreUploadedFile(IFormFile file)
+    {
+        var dir = GetTenorStorageDirectory();
+        var filename = new FileInfo(Path.Join(dir.FullName, file.FileName));
+        if (filename.Directory?.FullName != dir.FullName)
+        {
+            throw new Exception($"Invalid filename {file.FileName}");
+        }
+        using Stream fileStream = filename.OpenWrite();
+        await file.CopyToAsync(fileStream);
+    }
+    private static T? ParseCatchException<T>(string rawJson) where T : class
+    {
+        try
+        {
+            return JsonSerializer.Deserialize<T>(rawJson, _options);
+        }
+        catch (Exception)
+        {
+            return null;
+        }
+    }
+    public async Task<List<TenorFileItem>> GetFileItems()
+    {
+        var directory = GetTenorStorageDirectory();
+        var itemList = new List<TenorFileItem>();
+        foreach (var f in directory.GetFiles())
+        {
+            if (f.Name.StartsWith('.'))
+            {
+                continue; // Ignore hidden files (like .DS_Store)
+            }
+            var content = await System.IO.File.ReadAllTextAsync(f.FullName);
+
+            itemList.Add(new()
+            {
+                FileName = f.Name,
+                RawFileContent = content,
+                Freg = ParseCatchException<Freg>(content),
+                Brreg = ParseCatchException<BrregErFr>(content),
+            });
+        };
+        return itemList;
+    }
+
+    public void DeleteFile(string fileName)
+    {
+        var fileHandle = GetTenorStorageDirectory().GetFiles(fileName).First(f => f.Name == fileName);
+        fileHandle.Delete();
+    }
+}
+
+public static class ListExtentions
+{
+    public static T? FirstErGjeldende<T>(this List<T> list)
+    {
+        var erGjeldendeAccessor = typeof(T).GetProperty("erGjeldende");
+        return list.FirstOrDefault(t => erGjeldendeAccessor?.GetValue(t) as bool? == true) ?? list.FirstOrDefault();
+    }
+}

--- a/src/Services/Tenor/TenorDataReader.cs
+++ b/src/Services/Tenor/TenorDataReader.cs
@@ -23,7 +23,12 @@ public class TenorDataRepository
 
     public DirectoryInfo GetTenorStorageDirectory()
     {
-        return new DirectoryInfo(Path.Join(_settings.LocalTestingStorageBasePath, _settings.TenorDataFolder));
+        var dir = new DirectoryInfo(Path.Join(_settings.LocalTestingStorageBasePath, _settings.TenorDataFolder));
+        if (!dir.Exists)
+        {
+            dir.Create();
+        }
+        return dir;
     }
 
 
@@ -32,10 +37,6 @@ public class TenorDataRepository
         var freg = new List<Freg>();
         var brregErFr = new List<BrregErFr>();
         var tenorFolder = GetTenorStorageDirectory();
-        if (!tenorFolder.Exists)
-        {
-            return (brregErFr, freg);
-        }
 
         foreach (var fregFile in tenorFolder.GetFiles("freg.*.kildedata.json").Where(f => files?.Contains(f.Name) ?? true))
         {

--- a/src/Services/TestData/AppTestDataModel.cs
+++ b/src/Services/TestData/AppTestDataModel.cs
@@ -1,4 +1,5 @@
 #nullable enable
+using System.Text.Json.Serialization;
 using Altinn.Platform.Authentication.Model;
 using Altinn.Platform.Profile.Models;
 using Altinn.Platform.Register.Models;
@@ -12,7 +13,12 @@ namespace LocalTest.Services.TestData;
 /// </summary>
 public class AppTestDataModel
 {
+    [JsonPropertyOrder(int.MinValue)]
+    [JsonPropertyName("$schema")]
+    public string Schema => "https://altinncdn.no/schemas/json/test-users/test-users.schema.v1.json";
+    [JsonPropertyName("persons")]
     public List<AppTestPerson> Persons { get; set; } = default!;
+    [JsonPropertyName("orgs")]
     public List<AppTestOrg> Orgs { get; set; } = default!;
 
     public TestDataModel GetTestDataModel()
@@ -155,27 +161,49 @@ public class AppTestDataModel
         };
         return constructedAppData;
     }
+
+    public bool IsEmpty()
+    {
+        return Persons.Count == 0 && Orgs.Count == 0;
+    }
 }
 
 public class AppTestOrg
 {
+    [JsonPropertyName("partyId")]
     public int PartyId { get; set; }
+    [JsonPropertyName("orgNumber")]
     public string OrgNumber { get; set; } = default!;
 
+    [JsonPropertyName("parentPartyId")]
     public int? ParentPartyId { get; set; }
+    [JsonPropertyName("name")]
     public string? Name { get; set; }
+    [JsonPropertyName("businessAddress")]
     public string? BusinessAddress { get; set; }
+    [JsonPropertyName("businessPostalCity")]
     public string? BusinessPostalCity { get; set; }
+    [JsonPropertyName("businessPostalCode")]
     public string? BusinessPostalCode { get; set; }
+    [JsonPropertyName("eMailAddress")]
     public string? EMailAddress { get; set; }
+    [JsonPropertyName("faxNumber")]
     public string? FaxNumber { get; set; }
+    [JsonPropertyName("internetAddress")]
     public string? InternetAddress { get; set; }
+    [JsonPropertyName("mailingAddress")]
     public string? MailingAddress { get; set; }
+    [JsonPropertyName("mailingPostalCity")]
     public string? MailingPostalCity { get; set; }
+    [JsonPropertyName("mailingPostalCode")]
     public string? MailingPostalCode { get; set; }
+    [JsonPropertyName("mobileNumber")]
     public string? MobileNumber { get; set; }
+    [JsonPropertyName("telephoneNumber")]
     public string? TelephoneNumber { get; set; }
+    [JsonPropertyName("unitStatus")]
     public string? UnitStatus { get; set; }
+    [JsonPropertyName("unitType")]
     public string? UnitType { get; set; }
 
     public Party ToParty(List<AppTestOrg>? potentialChildOrgs = null)
@@ -226,28 +254,51 @@ public class AppTestOrg
 
 public class AppTestPerson
 {
+    [JsonPropertyName("partyId")]
     public int PartyId { get; set; } = default!;
+    [JsonPropertyName("ssn")]
     public string SSN { get; set; } = default!;
-    public string FirstName { get; set; } = default!;
-    public string MiddleName { get; set; } = default!;
+    [JsonPropertyName("firstName")]
+    public string? FirstName { get; set; } = default!;
+    [JsonPropertyName("middleName")]
+    public string? MiddleName { get; set; }
+    [JsonPropertyName("lastName")]
     public string LastName { get; set; } = default!;
+    [JsonPropertyName("customClaims")]
     public List<CustomClaim> CustomClaims { get; set; } = new();
+    [JsonPropertyName("partyRoles")]
     public Dictionary<int, List<Role>> PartyRoles { get; set; } = new();
+    [JsonPropertyName("addressCity")]
     public string? AddressCity { get; set; }
+    [JsonPropertyName("addressHouseLetter")]
     public string? AddressHouseLetter { get; set; }
+    [JsonPropertyName("addressHouseNumber")]
     public string? AddressHouseNumber { get; set; }
+    [JsonPropertyName("addressMunicipalName")]
     public string? AddressMunicipalName { get; set; }
+    [JsonPropertyName("addressMunicipalNumber")]
     public string? AddressMunicipalNumber { get; set; }
+    [JsonPropertyName("addressPostalCode")]
     public string? AddressPostalCode { get; set; }
+    [JsonPropertyName("addressStreetName")]
     public string? AddressStreetName { get; set; }
+    [JsonPropertyName("mailingAddress")]
     public string? MailingAddress { get; set; }
+    [JsonPropertyName("mailingPostalCity")]
     public string? MailingPostalCity { get; set; }
+    [JsonPropertyName("mailingPostalCode")]
     public string? MailingPostalCode { get; set; }
+    [JsonPropertyName("mobileNumber")]
     public string? MobileNumber { get; set; }
+    [JsonPropertyName("telephoneNumber")]
     public string? TelephoneNumber { get; set; }
+    [JsonPropertyName("email")]
     public string? Email { get; set; }
+    [JsonPropertyName("userId")]
     public int UserId { get; set; }
+    [JsonPropertyName("language")]
     public string? Language { get; set; }
+    [JsonPropertyName("userName")]
     public string? UserName { get; set; }
 
     public string GetFullName() => string.IsNullOrWhiteSpace(MiddleName) ? $"{FirstName} {LastName}" : $"{FirstName} {MiddleName} {LastName}";

--- a/src/Services/TestData/TestDataService.cs
+++ b/src/Services/TestData/TestDataService.cs
@@ -9,13 +9,15 @@ namespace LocalTest.Services.TestData;
 public class TestDataService
 {
     private readonly ILocalApp _localApp;
-    private readonly LocalPlatformSettings _settings;
+    private readonly TenorDataRepository _tenorDataRepository;
     private readonly IMemoryCache _cache;
+    private readonly LocalPlatformSettings _settings;
     private readonly ILogger<TestDataService> _logger;
-    public TestDataService(ILocalApp localApp, IOptions<LocalPlatformSettings> settings, IMemoryCache memoryCache, ILogger<TestDataService> logger)
+    public TestDataService(ILocalApp localApp, TenorDataRepository tenorDataRepository, IOptions<LocalPlatformSettings> settings, IMemoryCache memoryCache, ILogger<TestDataService> logger)
     {
-        _cache = memoryCache;
         _localApp = localApp;
+        _tenorDataRepository = tenorDataRepository;
+        _cache = memoryCache;
         _settings = settings.Value;
         _logger = logger;
     }
@@ -42,6 +44,14 @@ public class TestDataService
                     _logger.LogInformation(e, "Fetching Test data from app failed.");
                 }
 
+                var tenorUsers = await _tenorDataRepository.GetAppTestDataModel();
+                if (tenorUsers is not null && !tenorUsers.IsEmpty())
+                {
+                    // Use tenor users if they exist
+                    return tenorUsers.GetTestDataModel();
+                }
+
+                //Fallback to Ola Nordmann, Sofie Salt ... if no other users are availible
                 return await TestDataDiskReader.ReadFromDisk(_settings.LocalTestingStaticTestDataPath);
             }))!;
     }

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -109,6 +109,7 @@ namespace LocalTest
             services.AddSingleton<IPDP, PDPAppSI>();
             services.AddTransient<IPersonLookup, PersonLookupService>();
             services.AddTransient<TestDataService>();
+            services.AddTransient<TenorDataRepository>();
 
             services.AddSingleton<IContextHandler, ContextHandler>();
             services.AddSingleton<IPolicyRetrievalPoint, PolicyRetrievalPoint>();

--- a/src/Views/FrontendVersion/Index.cshtml
+++ b/src/Views/FrontendVersion/Index.cshtml
@@ -1,13 +1,13 @@
 ﻿@model FrontendVersion
 
 @{
-    ViewData["Title"] = "Frontend version";
+  ViewData["Title"] = "Frontend version";
 }
 <h1>@ViewData["Title"]</h1>
 
-@using (Html.BeginForm("FrontendVersion", "Home", FormMethod.Post, new { Class = "form-signin" }))
+@using (Html.BeginForm("Index", "FrontendVersion", FormMethod.Post, new { Class = "form-signin" }))
 {
-  @Html.AntiForgeryToken();
+  @Html.AntiForgeryToken()
   <div class="form-group">
     <label for="exampleInputEmail1">Select your desired frontend version</label>
     @Html.DropDownListFor(model => model.Version, Model.Versions, new { Class = "form-control" })

--- a/src/Views/Home/Index.cshtml
+++ b/src/Views/Home/Index.cshtml
@@ -84,7 +84,6 @@
         <label for="exampleInputEmail1">Select your authentication level</label>
         @Html.DropDownListFor(model => model.AuthenticationLevel, Model.AuthenticationLevels, new { Class = "form-control" })
       </div>
-      <button type="submit" class="btn btn-primary" name="action" value="reauthenticate">Refresh authentication</button>
       @if(Model.AppModeIsHttp)
       {
         <div class="form-group">
@@ -95,23 +94,16 @@
           <input class="form-control" type="file" id="prefill" name="prefill" accept=".xml"/>
         </div>
       }
-      <button type="submit" class="btn btn-primary" name="action" value="start">Proceed to app</button>
-    }
-
-    <div class="alert alert-light" role="alert">
-      To access attachments XML and other data, visit <a href="/LocalPlatformStorage/">/LocalPlatformStorage</a>
-    </div>
-
-    @if(string.IsNullOrWhiteSpace(Model.LocalFrontendUrl))
-    {
-      <div class="alert alert-light" role="alert">
-        @Html.ActionLink("Use a different frontend version", "FrontendVersion", "Home")
+      <div class="form-group">
+        <button type="submit" class="btn btn-light" name="action" value="reauthenticate">Refresh authentication</button>
+        <button type="submit" class="btn btn-primary" name="action" value="start">Proceed to app</button>
       </div>
     }
-    else
+
+    @if(!string.IsNullOrWhiteSpace(Model.LocalFrontendUrl))
     {
       <div class="alert alert-primary" role="alert">
-        You are using frontend js and css from @(Model.LocalFrontendUrl). @Html.ActionLink("Use a different frontend version", "FrontendVersion", "Home")
+        You are using frontend js and css from @(Model.LocalFrontendUrl). @Html.ActionLink("Use a different frontend version", "Index", "FrontendVersion")
       </div>
     }
   </div>

--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -26,7 +26,7 @@
                                 asp-action="Index">Pick frontend version</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="TenorUsers"
+                            <a class="nav-link text-secondary" asp-area="" asp-controller="TenorUsers"
                                 asp-action="Index">User administration</a>
                         </li>
                         <li class="nav-item">

--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -42,12 +42,6 @@
             @RenderBody()
         </main>
     </div>
-
-    <footer class="border-top footer text-muted">
-        <div class="container">
-            &copy; 2019 - LocalTest
-        </div>
-    </footer>
     @RenderSection("Scripts", required: false)
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
 </body>

--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -4,20 +4,35 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - Altinn Studio</title>
-    <link rel="stylesheet" href="https://altinncdn.no/toolkits/bootstrap/4.5.2/css/bootstrap.min.css" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <link rel="stylesheet" href="~/localtestresources/css/site.css" />
 </head>
 <body>
     <header>
         <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
             <div class="container">
-                <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">Altinn Studio</a>
+                <a class="navbar-brand" asp-area="" asp-controller="Home" asp-action="Index">App Localtest</a>
                 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target=".navbar-collapse" aria-controls="navbarSupportedContent"
-                        aria-expanded="false" aria-label="Toggle navigation">
+                         aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>
                 </button>
-                <div class="navbar-collapse collapse d-sm-inline-flex flex-sm-row-reverse">
-
+                <div class="navbar-collapse collapse d-sm-inline-flex justify-content-between">
+                    <ul class="navbar-nav flex-grow-1">
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Login</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="FrontendVersion"
+                                asp-action="Index">Pick frontend version</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="TenorUsers"
+                                asp-action="Index">User administration</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="StorageExplorer" asp-action="Index">Storage Explorer</a>
+                        </li>
+                    </ul>
                 </div>
             </div>
         </nav>
@@ -30,9 +45,10 @@
 
     <footer class="border-top footer text-muted">
         <div class="container">
-            &copy; 2019 - LocalTest - <a asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
+            &copy; 2019 - LocalTest
         </div>
     </footer>
     @RenderSection("Scripts", required: false)
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
 </body>
 </html>

--- a/src/Views/StorageExplorer/Index.cshtml
+++ b/src/Views/StorageExplorer/Index.cshtml
@@ -1,0 +1,9 @@
+<script>
+    function resizeIframe(obj) {
+        obj.style.height = (obj.contentWindow.document.documentElement.scrollHeight + 40) + 'px';
+        obj.style.width = (obj.contentWindow.document.documentElement.scrollWidth + 5) + 'px';
+    }
+</script>
+
+<iframe src="/LocalPlatformStorage/" title="" style="width: 100%; min-height:50vh;" scrolling="auto"
+    onload="resizeIframe(this)"></iframe>

--- a/src/Views/StorageExplorer/Index.cshtml
+++ b/src/Views/StorageExplorer/Index.cshtml
@@ -1,9 +1,39 @@
-<script>
-    function resizeIframe(obj) {
-        obj.style.height = (obj.contentWindow.document.documentElement.scrollHeight + 40) + 'px';
-        obj.style.width = (obj.contentWindow.document.documentElement.scrollWidth + 5) + 'px';
-    }
-</script>
+<div class="alert alert-info" role="alert">
+    To get xml files to use for prefill, it is important to not just copy text from the browser preview, but to actually save directly to file in the browser.
+    <br><br>
+    This is because browser preview of xml removes some escaping, and you might get an invalid xml (eg <em>&amp;amp;</em> gets displayed as <em>&amp;</em>)
+</div>
 
-<iframe src="/LocalPlatformStorage/" title="" style="width: 100%; min-height:50vh;" scrolling="auto"
-    onload="resizeIframe(this)"></iframe>
+<iframe id="localPlatformIframe" src="/LocalPlatformStorage/" title="" style="width: 100%; min-height:50vh;"
+    scrolling="no" onload="resizeIframe(this)"></iframe>
+
+<script>
+    var iframe = document.getElementById("localPlatformIframe");
+    function resizeIframe() {
+        iframe.style.height = '100px';
+        iframe.style.width = '100%';
+        setTimeout(() => {
+            // ensure that actual size gets set after a render
+            var iframeDoc = iframe.contentWindow.document.documentElement;
+            iframe.style.height = (iframeDoc.scrollHeight + iframeDoc.sc) + 'px';
+            iframe.style.width = (iframeDoc.scrollWidth) + 'px';
+        }, 0);
+    }
+    function handleOnLoad(event) {
+        console.log(iframe.contentDocument.contentType);
+        if (iframe.contentDocument.contentType != "text/html") {
+            // Bust out of iframe when the content type isn't text/html
+            window.location.replace(iframe.contentWindow.location.href);
+            return;
+        }
+        resizeIframe();
+    }
+    iframe.addEventListener("load", handleOnLoad);
+    window.addEventListener("resize", resizeIframe);
+
+    var downloadButton = document.getElementById("download");
+    downloadButton.addEventListener("click", () => {
+        window.open(iframe.contentWindow.location.href, "_blank");
+    })
+
+</script>

--- a/src/Views/TenorUsers/Index.cshtml
+++ b/src/Views/TenorUsers/Index.cshtml
@@ -8,7 +8,7 @@
 
 
 @{
-    ViewData["Title"] = "Local users and orgs";
+    ViewData["Title"] = "Local users and orgs (preview)";
 }
 <h1>@ViewData["Title"]</h1>
 
@@ -23,6 +23,12 @@
     "kildedata" for the persons and organisations that you want to reference. Make sure you find suitable users and
     organisations and download "kildedata" for each org/user.
 </p>
+
+<div class="alert alert-info" role="alert">
+    Currently there isn't any syncronization between role assignments in tt02 and tenor, so you might need to manually
+    add the relevant roles for your apps to work as in tt02. The functionality presented here is mainly a simple way to
+    copy names, personal identification number and organization numbers.
+</div>
 
 <div class="card" style="width:30rem">
     <div class="card-header">
@@ -53,8 +59,8 @@
         <tr>
             <th>Velg</th>
             <th>Filename</th>
-            <th>Person name</th>
-            <th>Fnr</th>
+            <th>Name</th>
+            <th>Fnr/org</th>
             <th></th>
         </tr>
     </thead>
@@ -68,16 +74,16 @@
                     <td>@item.FileName</td>
                     @if (item.Brreg is not null)
                     {
+                        <td>@item.Brreg.Navn</td>
                         <td>@item.Brreg.Organisasjonsnummer</td>
-                        <td></td>
                         <td></td>
                     }
                     else if (item.Freg is not null)
                     {
 
-                        <td>@item.Freg.Identifikasjonsnummer?.FirstErGjeldende()?.FoedselsEllerDNummer</td>
                         <td>@item.Freg.Navn?.FirstErGjeldende()?.Fornavn @item.Freg.Navn?.FirstErGjeldende()?.Mellomnavn
                             @item.Freg.Navn?.FirstErGjeldende()?.Etternavn</td>
+                        <td>@item.Freg.Identifikasjonsnummer?.FirstErGjeldende()?.FoedselsEllerDNummer</td>
                         <td></td>
 
                     }

--- a/src/Views/TenorUsers/Index.cshtml
+++ b/src/Views/TenorUsers/Index.cshtml
@@ -1,0 +1,98 @@
+@model LocalTest.Models.TenorViewModel
+
+@using Microsoft.Extensions.Options
+@using LocalTest.Configuration
+@using LocalTest.Services.TestData
+
+@inject IOptions<LocalPlatformSettings> LocalPlatformSettings
+
+
+@{
+    ViewData["Title"] = "Local users and orgs";
+}
+<h1>@ViewData["Title"]</h1>
+
+<p>
+    By default Altinn Studio publishes a limited set of test accouns for local testing. For most apps these will be
+    enough, but if you have more specific needs, or want the same users as in tt02, you probably want to import data
+    from <a href="https://www.skatteetaten.no/skjema/testdata/">Tenor testdata</a> to use for your local development
+</p>
+
+<p>
+    Tenor requires login with an official norwegian ID (like BankID), so you currently have to login and download
+    "kildedata" for the persons and organisations that you want to reference. Make sure you find suitable users and
+    organisations and download "kildedata" for each org/user.
+</p>
+
+<div class="card" style="width:30rem">
+    <div class="card-header">
+        <h3 class="card-title">Last opp tenor kildefiler</h3>
+    </div>
+    @using (Html.BeginForm("Upload", "TenorUsers", FormMethod.Post, new
+    {
+        Class = "form-signin",
+        enctype =
+    "multipart/form-data"
+    }))
+    {
+        @Html.AntiForgeryToken()
+        ;
+        <div class="card-body">
+            <input type="file" class="form-control" name="tenorJsonFiles" multiple="multiple" />
+        </div>
+        <div class="card-body">
+            <input type="submit" class="btn btn-primary" value="Save json files to storage" />
+        </div>
+    }
+</div>
+
+@using (Html.BeginForm("Update", "TenorUsers", FormMethod.Post, new { }))
+{
+    <table class="table">
+    <thead>
+        <tr>
+            <th>Velg</th>
+            <th>Filename</th>
+            <th>Person name</th>
+            <th>Fnr</th>
+            <th></th>
+        </tr>
+    </thead>
+    <tbody>
+        @foreach (var item in Model.FileItems)
+            {
+                <tr>
+                    <td><input type="checkbox" name="@item.FileName" /></td>
+                    <td>@item.FileName</td>
+                    @if (item.Brreg is not null)
+                    {
+                        <td>@item.Brreg.Organisasjonsnummer</td>
+                        <td></td>
+                        <td></td>
+                    }
+                    else if (item.Freg is not null)
+                    {
+
+                        <td>@item.Freg.Identifikasjonsnummer?.FirstErGjeldende()?.FoedselsEllerDNummer</td>
+                        <td>@item.Freg.Navn?.FirstErGjeldende()?.Fornavn @item.Freg.Navn?.FirstErGjeldende()?.Mellomnavn
+                            @item.Freg.Navn?.FirstErGjeldende()?.Etternavn</td>
+                        <td></td>
+
+                    }
+                    else
+                    {
+                        <td colspan="3">
+                            <pre>@item.RawFileContent</pre>
+                        </td>
+
+                    }
+                </tr>
+            }
+        </tbody>
+    </table>
+    <input type="submit" name="Delete" class="btn btn-danger" value="Slett markerte" />
+    <div class="btn-group">
+        <input type="submit" name="Download" class="btn btn-primary" value="Last ned som altinn studo json" />
+        <input type="submit" name="DownloadFile" class="btn btn-secondary" value="▼" />
+    </div>
+}

--- a/src/Views/TenorUsers/Index.cshtml
+++ b/src/Views/TenorUsers/Index.cshtml
@@ -38,10 +38,10 @@
         @Html.AntiForgeryToken()
         ;
         <div class="card-body">
-            <input type="file" class="form-control" name="tenorJsonFiles" multiple="multiple" />
+            <input type="file" class="form-control" accept=".json, application/json" name="tenorJsonFiles" multiple="multiple" />
         </div>
         <div class="card-body">
-            <input type="submit" class="btn btn-primary" value="Save json files to storage" />
+            <input type="submit" class="btn btn-primary" value="Upload tenor files to storage" />
         </div>
     }
 </div>
@@ -61,8 +61,10 @@
     <tbody>
         @foreach (var item in Model.FileItems)
             {
-                <tr>
-                    <td><input type="checkbox" name="@item.FileName" /></td>
+                <tr class='@(item.Valid ? "":"table-danger")'>
+                    <td>
+                        <input type="checkbox" name="@item.FileName" />
+                    </td>
                     <td>@item.FileName</td>
                     @if (item.Brreg is not null)
                     {
@@ -92,7 +94,7 @@
     </table>
     <input type="submit" name="Delete" class="btn btn-danger" value="Slett markerte" />
     <div class="btn-group">
-        <input type="submit" name="Download" class="btn btn-primary" value="Last ned som altinn studo json" />
-        <input type="submit" name="DownloadFile" class="btn btn-secondary" value="▼" />
+        <input type="submit" name="DownloadFile" class="btn btn-primary" value="Last ned markerte personer og enheter som testData.json" />
+        <input type="submit" name="Download" class="btn btn-secondary" value="Vis testData.json " />
     </div>
 }


### PR DESCRIPTION
Now you can open a separate tab on the localtest site and upload tenor
kildedata to localtest internal storage. If there are relevant tenor files
in storage, those will replace Ola Nordmann and Sofie Salt as the localtest
users. You can also select a subset of the files to downoad testData.json
to be used as app local users.

![Screenshot 2023-10-12 at 11 00 43](https://github.com/Altinn/app-localtest/assets/131616/447e3dc2-5272-4ed1-958c-6a3a1911ece9)


3622.87.84340

In addtition to the user management page, I have included the following changes.
* Cleanup of login page and use the menu on top instead of links scattered all over the login screen
* Use latest bootstrap (from CDN, per getboostrap.com instructions)
* Split HomeController into multiple smaller controllers.
* Move `Reauthenticate` button besides the login button and make it a less visible color.
* Loadbalancer redirects "/" and /Home/* to localtest, so all new controllers got a `/Home/[controller]/[action]` prefix
* use only spaces (not mixed with tabs) in nginx.conf.conf

## Related Issue(s)
- #59 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
