### PR TITLE
Add HTTP attributes to actions in HomeController

### DIFF
--- a/src/Controllers/HomeController.cs
+++ b/src/Controllers/HomeController.cs
@@ -180,6 +180,7 @@ namespace LocalTest.Controllers
         /// </summary>
         /// <param name="userId"></param>
         /// <returns></returns>
+        [HttpGet("{userId}")]
         public async Task<ActionResult> GetTestUserToken(int userId)
         {
             UserProfile profile = await _userProfileService.GetUser(userId);
@@ -199,6 +200,7 @@ namespace LocalTest.Controllers
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>
+        [HttpGet("{id}")]
         public async Task<ActionResult> GetTestOrgToken(string id, [FromQuery] string orgNumber = null)
         {
             // Create a test token with long duration


### PR DESCRIPTION
## Description
HTTP attributes were missing for actions `GetTestUserToken` and `GetTestOrgToken` making them unusable. This PR annotates the actions with `HttpGet` attribute with a binding to the input parameter so that they can be used again.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
