### PR TITLE
add controller for handling generic events

### DIFF
--- a/src/Controllers/Events/AppController.cs
+++ b/src/Controllers/Events/AppController.cs
@@ -1,0 +1,65 @@
+using Altinn.Platform.Events.Models;
+using Altinn.Platform.Events.Repository;
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace Altinn.Platform.Events.Controllers
+{
+    /// <summary>
+    /// Provides operations for handling app events
+    /// </summary>
+    [Route("events/api/v1/app")]
+    [ApiController]
+    public class AppController : ControllerBase
+    {
+        private readonly IEventsRepository _repository;
+        private readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AppController"/> class
+        /// </summary>
+        /// <param name="repository">the events repository handler</param>
+        /// <param name="logger">dependency injection of logger</param>
+        public AppController(IEventsRepository repository, ILogger<EventsController> logger)
+        {
+            _repository = repository;
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Inserts a new event.
+        /// </summary>
+        /// <param name="cloudEvent">The event to store.</param>
+        /// <returns>The application metadata object.</returns>
+        [HttpPost]
+        [Consumes("application/json")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [Produces("application/json")]
+        public async Task<ActionResult<string>> Post([FromBody] CloudEvent cloudEvent)
+        {
+            if (string.IsNullOrEmpty(cloudEvent.Source.OriginalString) || string.IsNullOrEmpty(cloudEvent.Specversion) ||
+            string.IsNullOrEmpty(cloudEvent.Type) || string.IsNullOrEmpty(cloudEvent.Subject))
+            {
+                return BadRequest("Missing parameter values: source, subject, type, id or time cannot be null");
+            }
+
+            try
+            {
+                // Force cosmos to create id
+                cloudEvent.Id = null;
+
+                string cloudEventId = await _repository.Create(cloudEvent);
+
+                _logger.LogInformation("Cloud Event successfully stored with id: {0}", cloudEventId);
+
+                return Created(cloudEvent.Subject, cloudEventId);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError($"Unable to store cloud event in database. {e}");
+                return StatusCode(500, $"Unable to store cloud event in database. {e}");
+            }
+        }
+    }
+}

--- a/src/Controllers/Events/EventsController.cs
+++ b/src/Controllers/Events/EventsController.cs
@@ -1,19 +1,14 @@
-using System;
-using System.Threading.Tasks;
-
 using Altinn.Platform.Events.Models;
 using Altinn.Platform.Events.Repository;
 
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
 
 namespace Altinn.Platform.Events.Controllers
 {
     /// <summary>
-    /// Provides operations for handling events
+    /// Provides operations for handling generic events
     /// </summary>
-    [Route("events/api/v1/app")]
+    [Route("events/api/v1/events")]
     [ApiController]
     public class EventsController : ControllerBase
     {
@@ -40,31 +35,41 @@ namespace Altinn.Platform.Events.Controllers
         [Consumes("application/json")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [Produces("application/json")]
+        [Produces("application/cloudevents+json")]
         public async Task<ActionResult<string>> Post([FromBody] CloudEvent cloudEvent)
         {
-            if (string.IsNullOrEmpty(cloudEvent.Source.OriginalString) || string.IsNullOrEmpty(cloudEvent.Specversion) ||
-            string.IsNullOrEmpty(cloudEvent.Type) || string.IsNullOrEmpty(cloudEvent.Subject))
+            var (isValid, errorMessages) = ValidateCloudEvent(cloudEvent);
+            if (!isValid)
             {
-                return BadRequest("Missing parameter values: source, subject, type, id or time cannot be null");
+                return Problem(errorMessages, null, 400);
             }
-
+            
             try
             {
-                // Force cosmos to create id
-                cloudEvent.Id = null;
-
-                string cloudEventId = await _repository.Create(cloudEvent);
-
+                var cloudEventId = await _repository.Create(cloudEvent);
                 _logger.LogInformation("Cloud Event successfully stored with id: {0}", cloudEventId);
-
-                return Created(cloudEvent.Subject, cloudEventId);
+                return Ok();
             }
-            catch (Exception e)
+            catch (Exception exception)
             {
-                _logger.LogError($"Unable to store cloud event in database. {e}");
-                return StatusCode(500, $"Unable to store cloud event in database. {e}");
+                _logger.LogError(exception, "Unable to register cloud event.");
+                return StatusCode(500, $"Unable to register cloud event.");
             }
+        }
+        
+        private static (bool IsValid, string ErrorMessage) ValidateCloudEvent(CloudEvent cloudEvent)
+        {
+            if (string.IsNullOrEmpty(cloudEvent.Resource))
+            {
+                return (false, "A 'resource' property must be defined.");
+            }
+
+            if (!Uri.IsWellFormedUriString(cloudEvent.Resource, UriKind.Absolute))
+            {
+                return (false, "'Resource' must be a valid urn.");
+            }
+
+            return (true, null);
         }
     }
 }

--- a/src/Models/Events/CloudEvent.cs
+++ b/src/Models/Events/CloudEvent.cs
@@ -1,4 +1,3 @@
-using System;
 using Newtonsoft.Json;
 
 namespace Altinn.Platform.Events.Models
@@ -50,5 +49,11 @@ namespace Altinn.Platform.Events.Models
         /// </summary>
         [JsonProperty(PropertyName = "alternativesubject")]
         public string Alternativesubject { get; set; }
+
+        /// <summary>
+        /// Gets or sets the resource of the event
+        /// </summary>
+        [JsonProperty(PropertyName = "resource")]
+        public string Resource { get; set; }
     }
 }


### PR DESCRIPTION
## Description
The purpose of this PR is to synchronize the endpoints for events between Altinn Platform and localtest. In Altinn Events API, there are two endpoints for processing events. One for app events, and one for generic events. Currently, only the app events endpoint is present in localtest.

The PR adds an endpoint for processing generic events. Validation works the same as in Altinn Events API. However, as with app events, the events are just saved to a file and not done anything with.

The added endpoint for generic events is the same as the app events endpoint with some minor tweaks for validation and routing.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green
