### PR TITLE
Bugfix make podman work on fedora, apple silicone and windows OS

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -17,3 +17,6 @@
 ## add it here
 
 #TEST_DOMAIN=local.altinn.cloud
+
+## Change pod where local running version of app-frontend is running
+#LOCAL_FRONTEND_PORT=8080

--- a/.env.template
+++ b/.env.template
@@ -4,7 +4,8 @@
 
 ## What port should the loadbalancer use?
 ## sometimes PCs have another service running on port 80, so you might need to
-## change this. Default in podman-compose.yml is 8080 as ports below 1024 are privileged ports on most unix systems.
+## change this. 
+## Default in podman-compose.yml is 8000 as ports below 1024 are privileged ports on most unix systems.
 
 #ALTINN3LOCAL_PORT=80
 
@@ -17,6 +18,3 @@
 ## add it here
 
 #TEST_DOMAIN=local.altinn.cloud
-
-## Change pod where local running version of app-frontend is running
-#LOCAL_FRONTEND_PORT=8080

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,9 @@ podman-compose-stop-localtest:
 	podman-compose --file podman-compose.yml down
 		
 
-.PHONY: podman-applehv-bind-hack
-podman-applehv-bind-hack:
-	@echo "Running best effort commands to make bind mounts work on Apple Silicon with podman and applehv. Dirty hack until actual issue is located and fixed."
+.PHONY: podman-bind-fix-hack
+podman-selinux-bind-hack:
+	@echo "Running best effort commands to make bind mounts work on Apple Silicon and Linux with podman. Dirty hack until actual issue is located and fixed."
 	podman container run -v ./testdata/:/testdata/:z --rm -it --entrypoint cat nginx:alpine-perl /testdata/authorization/claims/1337.json > /dev/null
 	podman container run -v ./loadbalancer/templates/:/testdata/:z --rm -it --entrypoint cat nginx:alpine-perl /testdata/nginx.conf.conf > /dev/null
+	podman container run -v ./loadbalancer/www/:/testdata/:z --rm -it --entrypoint cat nginx:alpine-perl /testdata/502App.html > /dev/null

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,18 @@ podman-start-localtest:
 .PHONY: podman-stop-localtest
 podman-stop-localtest:
 	podman compose --file podman-compose.yml down
+	
+.PHONY: podman-compose-start-localtest
+podman-compose-start-localtest:
+	podman-compose --file podman-compose.yml up -d --build
+	
+.PHONY: podman-compose-stop-localtest
+podman-compose-stop-localtest:
+	podman-compose --file podman-compose.yml down
+		
+
+.PHONY: podman-applehv-bind-hack
+podman-applehv-bind-hack:
+	@echo "Running best effort commands to make bind mounts work on Apple Silicon with podman and applehv. Dirty hack until actual issue is located and fixed."
+	podman container run -v ./testdata/:/testdata/:z --rm -it --entrypoint cat nginx:alpine-perl /testdata/authorization/claims/1337.json > /dev/null
+	podman container run -v ./loadbalancer/templates/:/testdata/:z --rm -it --entrypoint cat nginx:alpine-perl /testdata/nginx.conf.conf > /dev/null

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,6 @@ podman-compose-stop-localtest:
 .PHONY: podman-selinux-bind-hack
 podman-selinux-bind-hack:
 	@echo "Running best effort commands to make bind mounts work on Apple Silicon and Linux with podman. Dirty hack until actual issue is located and fixed."
-	podman container run -v ./testdata/:/testdata/:z --rm -it --entrypoint cat nginx:alpine-perl /testdata/authorization/claims/1337.json > /dev/null
-	podman container run -v ./loadbalancer/templates/:/testdata/:z --rm -it --entrypoint cat nginx:alpine-perl /testdata/nginx.conf.conf > /dev/null
-	podman container run -v ./loadbalancer/www/:/testdata/:z --rm -it --entrypoint cat nginx:alpine-perl /testdata/502App.html > /dev/null
+	podman container run -v ./testdata/:/testdata/:Z --rm -it --entrypoint cat nginx:alpine-perl /testdata/authorization/claims/1337.json > /dev/null
+	podman container run -v ./loadbalancer/templates/:/testdata/:Z --rm -it --entrypoint cat nginx:alpine-perl /testdata/nginx.conf.conf > /dev/null
+	podman container run -v ./loadbalancer/www/:/testdata/:Z --rm -it --entrypoint cat nginx:alpine-perl /testdata/502App.html > /dev/null

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ podman-compose-stop-localtest:
 	podman-compose --file podman-compose.yml down
 		
 
-.PHONY: podman-bind-fix-hack
+.PHONY: podman-selinux-bind-hack
 podman-selinux-bind-hack:
 	@echo "Running best effort commands to make bind mounts work on Apple Silicon and Linux with podman. Dirty hack until actual issue is located and fixed."
 	podman container run -v ./testdata/:/testdata/:z --rm -it --entrypoint cat nginx:alpine-perl /testdata/authorization/claims/1337.json > /dev/null

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ These are some of the required steps, tips, and tricks when it comes to running 
      provider = "applehv"
    ```
 
+   Start the containers with the following command:
+
    ```shell
    podman compose --file podman-compose.yml up -d --build
    ```

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ These are some of the required steps, tips, and tricks when it comes to running 
     ```shell
     docker compose up -d --build
     ```
+   
    > [!NOTE]
    > If you are using linux or mac you can use the Makefile to build and run the containers.
 
@@ -69,15 +70,15 @@ These are some of the required steps, tips, and tricks when it comes to running 
 
 2. Build and run the containers in the background.
 
-> [!IMPORTANT]
-> If you are using an mac with either a M2 or M3 chip you may need to use `applehv` instead of `qemu` as the podman machine driver. 
-> This can be done by setting the environment variable `PODMAN_MACHINE_DRIVER` to `applehv` before running the command below.
-> If you are using Podman Desktop you also need to add these lines in `~/.config/containers/containers.conf` (check if the `[machine]` section already exists):
->  
-> ```
-> [machine]
->   provider = "applehv"
-> ```
+    > [!IMPORTANT]
+    > If you are using an mac with either a M2 or M3 chip you may need to use `applehv` instead of `qemu` as the podman machine driver. 
+    > This can be done by setting the environment variable `PODMAN_MACHINE_DRIVER` to `applehv` before running the command below.
+    > If you are using Podman Desktop you also need to add these lines in `~/.config/containers/containers.conf` (check if the `[machine]` section already exists):
+    >  
+    > ```
+    > [machine]
+    >   provider = "applehv"
+    > ```
 
    Start the containers with the following command:
 

--- a/README.md
+++ b/README.md
@@ -233,3 +233,9 @@ if you get a permission denied message this verifies that the bind mount is not 
 ```shell
 make podman-selinux-bind-hack
 ```
+
+#### Running Podman on windows with Hyper-V Firewall enabled requires opening port 5005 to the host machine
+
+Check if _local rule merging_ is set to _"No"_ as described [here](https://learn.microsoft.com/en-us/windows/wsl/troubleshooting#wsl-has-no-network-connection-on-my-work-machine-or-in-an-enterprise-environment).
+
+If this is the case you can open a Windows Powershell as administrator and run the script `OpenAppPortInHyperVFirewall.ps1` located in the `scripts` folder.

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ These are some of the required steps, tips, and tricks when it comes to running 
     ```shell
     docker compose up -d --build
     ```
-
-   :information_source: If you are using linux or mac you can use the Makefile to build and run the containers.
+   > [!NOTE]
+   > If you are using linux or mac you can use the Makefile to build and run the containers.
 
     ```shell
     make docker-start-localtest
@@ -69,14 +69,15 @@ These are some of the required steps, tips, and tricks when it comes to running 
 
 2. Build and run the containers in the background.
 
-   If you are using an mac with either a M2 or M3 chip you may need to use `applehv` instead of `qemu` as the podman machine driver. 
-   This can be done by setting the environment variable `PODMAN_MACHINE_DRIVER` to `applehv` before running the command below.
-   If you are using Podman Desktop you also need to add these lines in `~/.config/containers/containers.conf` (check if the `[machine]` section already exists):
-    
-   ```
-   [machine]
-     provider = "applehv"
-   ```
+   > [!IMPORTANT]
+   > If you are using an mac with either a M2 or M3 chip you may need to use `applehv` instead of `qemu` as the podman machine driver. 
+   > This can be done by setting the environment variable `PODMAN_MACHINE_DRIVER` to `applehv` before running the command below.
+   > If you are using Podman Desktop you also need to add these lines in `~/.config/containers/containers.conf` (check if the `[machine]` section already exists):
+   >  
+   > ```
+   > [machine]
+   >   provider = "applehv"
+   > ```
 
    Start the containers with the following command:
 
@@ -84,23 +85,25 @@ These are some of the required steps, tips, and tricks when it comes to running 
    podman compose --file podman-compose.yml up -d --build
    ```
 
-   :information_source: If you are using linux or mac you can use the Makefile to build and run the containers.
+   > [!NOTE]
+   > If you are using linux or mac you can use the Makefile to build and run the containers.
 
    ```shell
    make podman-start-localtest
    ```
 
-   :warning_source: Are you running podman version < 4.7.0 you need to use the following command instead:
-
-   ```shell
-   podman-compose --file podman-compose.yml up -d --build
-   ```
-   
-   or the make command:
-
-   ```shell
-   make podman-compose-start-localtest
-   ```
+   > [!IMPORTANT]
+   > Are you running podman version < 4.7.0 you need to use the following command instead:
+   > 
+   > ```shell
+   > podman-compose --file podman-compose.yml up -d --build
+   > ```
+   > 
+   > or the make command:
+   > 
+   > ```shell
+   > make podman-compose-start-localtest
+   > ```
 
    This mode supports running one app at a time. If you need to run multiple apps at once, stop the localtest container with `podman stop localtest` and follow the instructions below to run LocalTest locally outside Docker.
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ podman compose --file podman-compose.yml up -d --build
 > make podman-compose-start-localtest
 > ```
 
-Localtest should now be runningn on port 8080 and can be accessed on <http://local.altinn.cloud:8080>.
+Localtest should now be runningn on port 8000 and can be accessed on <http://local.altinn.cloud:8000>.
 
 #### Option B: Start the containers using Docker
 

--- a/README.md
+++ b/README.md
@@ -234,8 +234,10 @@ if you get a permission denied message this verifies that the bind mount is not 
 make podman-selinux-bind-hack
 ```
 
-#### Running Podman on windows with Hyper-V Firewall enabled requires opening port 5005 to the host machine
+#### Localtest reports that the app is not running even though it is
 
-Check if _local rule merging_ is set to _"No"_ as described [here](https://learn.microsoft.com/en-us/windows/wsl/troubleshooting#wsl-has-no-network-connection-on-my-work-machine-or-in-an-enterprise-environment).
+If localtest and you app is running, but localtest reports that the app is not running, it might be that the port is not open in the firewall.
+
+You can verify if the app is running by opening `http://localhost:5005/<app-org-name>/<app-name>/swagger/index.html` (remember to replace `<app-org-name>` and `<app-name>` with the correct values).
 
 If this is the case you can open a Windows Powershell as administrator and run the script `OpenAppPortInHyperVFirewall.ps1` located in the `scripts` folder.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ podman compose --file podman-compose.yml up -d --build
 > make podman-compose-start-localtest
 > ```
 
+Localtest should now be runningn on port 8080 and can be accessed on <http://local.altinn.cloud:8080>.
+
 #### Option B: Start the containers using Docker
 
 This mode supports running one app at a time. If you need to run multiple apps at once, stop the localtest container with `docker stop localtest` and follow the instructions below to run LocalTest locally outside Docker.
@@ -86,6 +88,7 @@ docker compose up -d --build
 > make docker-start-localtest
 > ```
 
+Localtest should now be runningn on port 80 and can be accessed on <http://local.altinn.cloud:80>.
 
 #### Start your app
 _This step requires that you have already [created an app](https://docs.altinn.studio/app/getting-started/create-app/), added a [data model](https://docs.altinn.studio/app/development/data/data-model/data-models-tool/), and [cloned the app](https://docs.altinn.studio/app/getting-started/local-dev/) to your local environment._

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ These are some of the required steps, tips, and tricks when it comes to running 
     - Also
       install [recommended extensions](https://code.visualstudio.com/docs/editor/extension-gallery#_workspace-recommended-extensions) (
       f.ex. [C#](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp))
-4. [Docker Desktop](https://www.docker.com/products/docker-desktop) (possible licencing fee) or [Podman](https://podman.io)/[Podman Desktop](https://podman-desktop.io) (Linux users can also use native Docker)
-
+4. [Podman Desktop](https://podman-desktop.io)/[Podman](https://podman.io) (Linux users can also use native Docker) or [Docker Desktop](https://www.docker.com/products/docker-desktop) (Windows and Mac) This might require you to purchase a license.
+On mac with apple silicone (M1, M2, M3):
+5. [vfkit](https://github.com/crc-org/vfkit?tab=readme-ov-file#installation)
 ### Setup
 
 #### Clone the repository
@@ -37,8 +38,9 @@ cd app-localtest
 This mode supports running one app at a time. If you need to run multiple apps at once, stop the localtest container with `podman stop localtest` and follow the instructions below to run LocalTest locally outside Docker/Podman.
 
 > [!IMPORTANT]
-> If you are using an mac with either a M2 or M3 chip you may need to use `applehv` instead of `qemu` as the podman machine driver. 
-> This can be done by setting the environment variable `PODMAN_MACHINE_DRIVER` to `applehv` before running the command below.
+> If you are using an mac with either a M1, M2 or M3 chip you may need to use `applehv` instead of `qemu` as the podman machine driver. 
+> This can be done by setting the environment variable `CONTAINERS_MACHINE_PROVIDER` to `applehv` before running the command below.
+> To add this to your zsh profile run the following command: `echo "export CONTAINERS_MACHINE_PROVIDER=applehv" >> ~/.zprofile`
 > If you are using Podman Desktop you also need to add these lines in `~/.config/containers/containers.conf` (check if the `[machine]` section already exists):
 >  
 > ```

--- a/README.md
+++ b/README.md
@@ -69,15 +69,15 @@ These are some of the required steps, tips, and tricks when it comes to running 
 
 2. Build and run the containers in the background.
 
-   > [!IMPORTANT]
-   > If you are using an mac with either a M2 or M3 chip you may need to use `applehv` instead of `qemu` as the podman machine driver. 
-   > This can be done by setting the environment variable `PODMAN_MACHINE_DRIVER` to `applehv` before running the command below.
-   > If you are using Podman Desktop you also need to add these lines in `~/.config/containers/containers.conf` (check if the `[machine]` section already exists):
-   >  
-   > ```
-   > [machine]
-   >   provider = "applehv"
-   > ```
+> [!IMPORTANT]
+> If you are using an mac with either a M2 or M3 chip you may need to use `applehv` instead of `qemu` as the podman machine driver. 
+> This can be done by setting the environment variable `PODMAN_MACHINE_DRIVER` to `applehv` before running the command below.
+> If you are using Podman Desktop you also need to add these lines in `~/.config/containers/containers.conf` (check if the `[machine]` section already exists):
+>  
+> ```
+> [machine]
+>   provider = "applehv"
+> ```
 
    Start the containers with the following command:
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ These are some of the required steps, tips, and tricks when it comes to running 
 - [Changing configuration](#changing-configuration)
 - [Multiple apps at the same time (running LocalTest locally)](#multiple-apps-at-the-same-time-running-localtest-locally)
 - [Changing test data](#changing-test-data)
+- [Known issues](#known-issues)
 
 ### Prerequisites
 
@@ -212,3 +213,21 @@ This would be required if your app requires a role which none of the test users 
 
 4. Save and close the file
 5. Restart LocalTest
+
+### Known issues
+
+#### Bind mounts folders gives permission denied. Nginx returns default page
+
+On some nix systems you might experience problems with the bind mounts used by the containers. If you get the default nginx page when trying to access local.altinn.cloud this might be the case.
+
+To verify this you can run the following command:
+
+```shell
+podman container exec -it localtest-loadbalancer cat /etc/nginx/templates/nginx.conf.conf
+```
+
+if you get a permission denied message this verifies that the bind mount is not working. A best effort fix for this is to run the following command:
+
+```shell
+make podman-selinux-bind-hack
+```

--- a/README.md
+++ b/README.md
@@ -69,18 +69,18 @@ These are some of the required steps, tips, and tricks when it comes to running 
 
 2. Build and run the containers in the background.
 
-    If you are using an mac with either a M2 or M3 chip you may need to use `applehv` instead of `qemu` as the podman machine driver. 
-    This can be done by setting the environment variable `PODMAN_MACHINE_DRIVER` to `applehv` before running the command below.
-    If you are using Podman Desktop you also need to add these lines in `~/.config/containers/containers.conf` (check if the `[machine]` section already exists):
-    ```
-    [machine]
-      provider = "applehv"
-    ```
-   
+   If you are using an mac with either a M2 or M3 chip you may need to use `applehv` instead of `qemu` as the podman machine driver. 
+   This can be done by setting the environment variable `PODMAN_MACHINE_DRIVER` to `applehv` before running the command below.
+   If you are using Podman Desktop you also need to add these lines in `~/.config/containers/containers.conf` (check if the `[machine]` section already exists):
     
-    ```shell
-    podman compose --file podman-compose.yml up -d --build
-    ```
+   ```
+   [machine]
+     provider = "applehv"
+   ```
+
+   ```shell
+   podman compose --file podman-compose.yml up -d --build
+   ```
 
    :information_source: If you are using linux or mac you can use the Makefile to build and run the containers.
 
@@ -90,13 +90,13 @@ These are some of the required steps, tips, and tricks when it comes to running 
 
    :warning_source: Are you running podman version < 4.7.0 you need to use the following command instead:
 
-    ```shell
+   ```shell
    podman-compose --file podman-compose.yml up -d --build
    ```
    
-    or the make command:
+   or the make command:
 
-    ```shell
+   ```shell
    make podman-compose-start-localtest
    ```
 

--- a/README.md
+++ b/README.md
@@ -18,112 +18,84 @@ These are some of the required steps, tips, and tricks when it comes to running 
 
 ### Setup
 
-#### Using docker 
+#### Clone the repository
 
-1. Clone the `app-localtest` repository to a local folder and move into the folder.
+```shell
+git clone https://github.com/Altinn/app-localtest
+cd app-localtest
+ ```
 
-   ```shell
-   git clone https://github.com/Altinn/app-localtest
-   cd app-localtest
-   ```
+#### Option A: Start the containers using podman
 
-2. Build and run the containers in the background. 
+This mode supports running one app at a time. If you need to run multiple apps at once, stop the localtest container with `podman stop localtest` and follow the instructions below to run LocalTest locally outside Docker/Podman.
 
-    ```shell
+> [!IMPORTANT]
+> If you are using an mac with either a M2 or M3 chip you may need to use `applehv` instead of `qemu` as the podman machine driver. 
+> This can be done by setting the environment variable `PODMAN_MACHINE_DRIVER` to `applehv` before running the command below.
+> If you are using Podman Desktop you also need to add these lines in `~/.config/containers/containers.conf` (check if the `[machine]` section already exists):
+>  
+> ```
+> [machine]
+>   provider = "applehv"
+> ```
+
+Start the containers with the following command:
+
+```shell
+podman compose --file podman-compose.yml up -d --build
+```
+
+> [!NOTE]
+> If you are using linux or mac you can use the Makefile to build and run the containers.
+> 
+> ```shell
+> make podman-start-localtest
+> ```
+
+> [!IMPORTANT]
+> Are you running podman version < 4.7.0 you need to use the following command instead:
+> 
+> ```shell
+> podman-compose --file podman-compose.yml up -d --build
+> ```
+> 
+> or the make command:
+> 
+> ```shell
+> make podman-compose-start-localtest
+> ```
+
+#### Option B: Start the containers using Docker
+```shell
     docker compose up -d --build
     ```
    
-   > [!NOTE]
-   > If you are using linux or mac you can use the Makefile to build and run the containers.
-
-    ```shell
-    make docker-start-localtest
-    ```
+> [!NOTE]
+> If you are using linux or mac you can use the Makefile to build and run the containers.
+> 
+> ```shell
+> make docker-start-localtest
+> ```
    
-    This mode supports running one app at a time. If you need to run multiple apps at once, stop the localtest container with `docker stop localtest` and follow the instructions below to run LocalTest locally outside Docker.
+This mode supports running one app at a time. If you need to run multiple apps at once, stop the localtest container with `docker stop localtest` and follow the instructions below to run LocalTest locally outside Docker.
 
-3. Start your app
-    _This step requires that you have already [created an app](https://docs.altinn.studio/app/getting-started/create-app/), added a [data model](https://docs.altinn.studio/app/development/data/data-model/data-models-tool/), and [cloned the app](https://docs.altinn.studio/app/getting-started/local-dev/) to your local environment._
-  
-    Move into the `App` folder of your application.
 
-     Example: If your application is named `my-awesome-app` and is located in the folder `C:\my_applications`, run the following command:
+#### Start your app
+_This step requires that you have already [created an app](https://docs.altinn.studio/app/getting-started/create-app/), added a [data model](https://docs.altinn.studio/app/development/data/data-model/data-models-tool/), and [cloned the app](https://docs.altinn.studio/app/getting-started/local-dev/) to your local environment._
 
-    ```shell
-    cd C:\my_applications\my-awasome-app\App
-    ```
+Move into the `App` folder of your application.
 
-     Run the application:
+Example: If your application is named `my-awesome-app` and is located in the folder `C:\my_applications`, run the following command:
 
-     ```shell
-     dotnet run
-    ```
+```shell
+cd C:\my_applications\my-awasome-app\App
+```
 
-#### Using podman
+Run the application:
 
-1. Clone the `app-localtest` repository to a local folder and move into the folder.
-
-   ```shell
-   git clone https://github.com/Altinn/app-localtest
-   cd app-localtest
-   ```
-
-2. Build and run the containers in the background.
-
-    > [!IMPORTANT]
-    > If you are using an mac with either a M2 or M3 chip you may need to use `applehv` instead of `qemu` as the podman machine driver. 
-    > This can be done by setting the environment variable `PODMAN_MACHINE_DRIVER` to `applehv` before running the command below.
-    > If you are using Podman Desktop you also need to add these lines in `~/.config/containers/containers.conf` (check if the `[machine]` section already exists):
-    >  
-    > ```
-    > [machine]
-    >   provider = "applehv"
-    > ```
-
-   Start the containers with the following command:
-
-   ```shell
-   podman compose --file podman-compose.yml up -d --build
-   ```
-
-   > [!NOTE]
-   > If you are using linux or mac you can use the Makefile to build and run the containers.
-
-   ```shell
-   make podman-start-localtest
-   ```
-
-   > [!IMPORTANT]
-   > Are you running podman version < 4.7.0 you need to use the following command instead:
-   > 
-   > ```shell
-   > podman-compose --file podman-compose.yml up -d --build
-   > ```
-   > 
-   > or the make command:
-   > 
-   > ```shell
-   > make podman-compose-start-localtest
-   > ```
-
-   This mode supports running one app at a time. If you need to run multiple apps at once, stop the localtest container with `podman stop localtest` and follow the instructions below to run LocalTest locally outside Docker.
-
-3. Start your app
-   _This step requires that you have already [created an app](https://docs.altinn.studio/app/getting-started/create-app/), added a [data model](https://docs.altinn.studio/app/development/data/data-model/data-models-tool/), and [cloned the app](https://docs.altinn.studio/app/getting-started/local-dev/) to your local environment._
-
-   Move into the `App` folder of your application.
-
-   Example: If your application is named `my-awesome-app` and is located in the folder `C:\my_applications`, run the following command:
-
-    ```shell
-    cd C:\my_applications\my-awasome-app\App
-    ```
-
-   Run the application:
-
-     ```shell
-     dotnet run
-    ```
+ ```shell
+ dotnet run
+```
 
 The app and local platform services are now running locally. The app can be accessed on <http://local.altinn.cloud>.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ These are some of the required steps, tips, and tricks when it comes to running 
     - Also
       install [recommended extensions](https://code.visualstudio.com/docs/editor/extension-gallery#_workspace-recommended-extensions) (
       f.ex. [C#](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp))
-4. [Docker Desktop](https://www.docker.com/products/docker-desktop) (Linux users can also use native Docker)
+4. [Docker Desktop](https://www.docker.com/products/docker-desktop) (possible licencing fee) or [Podman](https://podman.io)/[Podman Desktop](https://podman-desktop.io) (Linux users can also use native Docker)
 
 ### Setup
 
@@ -69,6 +69,15 @@ These are some of the required steps, tips, and tricks when it comes to running 
 
 2. Build and run the containers in the background.
 
+    If you are using an mac with either a M2 or M3 chip you may need to use `applehv` instead of `qemu` as the podman machine driver. 
+    This can be done by setting the environment variable `PODMAN_MACHINE_DRIVER` to `applehv` before running the command below.
+    If you are using Podman Desktop you also need to add these lines in `~/.config/containers/containers.conf` (check if the `[machine]` section already exists):
+    ```
+    [machine]
+      provider = "applehv"
+    ```
+   
+    
     ```shell
     podman compose --file podman-compose.yml up -d --build
     ```
@@ -77,6 +86,18 @@ These are some of the required steps, tips, and tricks when it comes to running 
 
    ```shell
    make podman-start-localtest
+   ```
+
+   :warning_source: Are you running podman version < 4.7.0 you need to use the following command instead:
+
+    ```shell
+   podman-compose --file podman-compose.yml up -d --build
+   ```
+   
+    or the make command:
+
+    ```shell
+   make podman-compose-start-localtest
    ```
 
    This mode supports running one app at a time. If you need to run multiple apps at once, stop the localtest container with `podman stop localtest` and follow the instructions below to run LocalTest locally outside Docker.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ These are some of the required steps, tips, and tricks when it comes to running 
 
 - [Prerequisites](#prerequisites)
 - [Setup](#setup)
+  - [Clone the repository](#clone-the-repository)
+  - [Option A: Start the containers using podman](#option-a-start-the-containers-using-podman)
+  - [Option B: Start the containers using Docker](#option-b-start-the-containers-using-docker)
+  - [Start your app](#start-your-app)
+- [Changing configuration](#changing-configuration)
+- [Multiple apps at the same time (running LocalTest locally)](#multiple-apps-at-the-same-time-running-localtest-locally)
 - [Changing test data](#changing-test-data)
 
 ### Prerequisites
@@ -66,9 +72,12 @@ podman compose --file podman-compose.yml up -d --build
 > ```
 
 #### Option B: Start the containers using Docker
+
+This mode supports running one app at a time. If you need to run multiple apps at once, stop the localtest container with `docker stop localtest` and follow the instructions below to run LocalTest locally outside Docker.
+
 ```shell
-    docker compose up -d --build
-    ```
+docker compose up -d --build
+```
    
 > [!NOTE]
 > If you are using linux or mac you can use the Makefile to build and run the containers.
@@ -76,8 +85,6 @@ podman compose --file podman-compose.yml up -d --build
 > ```shell
 > make docker-start-localtest
 > ```
-   
-This mode supports running one app at a time. If you need to run multiple apps at once, stop the localtest container with `docker stop localtest` and follow the instructions below to run LocalTest locally outside Docker.
 
 
 #### Start your app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - NGINX_HOST=localhost
       - NGINX_PORT=80
       - TEST_DOMAIN=${TEST_DOMAIN:-local.altinn.cloud}
+      - HOST_DOMAIN=host.docker.internal
       - INTERNAL_DOMAIN=host.docker.internal
       - ALTINN3LOCAL_PORT=${ALTINN3LOCAL_PORT:-80}
       - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,7 +63,6 @@ services:
       context: .
     environment:
       - DOTNET_ENVIRONMENT=Docker
-      - LOCAL_FRONTEND_PORT=${LOCAL_FRONTEND_PORT:-8080}
       - ASPNETCORE_URLS=http://*:5101/
       - GeneralSettings__BaseUrl=http://${TEST_DOMAIN:-local.altinn.cloud}:${ALTINN3LOCAL_PORT:-80}
       - GeneralSettings__HostName=${TEST_DOMAIN:-local.altinn.cloud}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       context: .
     environment:
       - DOTNET_ENVIRONMENT=Docker
+      - LOCAL_FRONTEND_PORT=${LOCAL_FRONTEND_PORT:-8080}
       - ASPNETCORE_URLS=http://*:5101/
       - GeneralSettings__BaseUrl=http://${TEST_DOMAIN:-local.altinn.cloud}:${ALTINN3LOCAL_PORT:-80}
       - GeneralSettings__HostName=${TEST_DOMAIN:-local.altinn.cloud}

--- a/loadbalancer/templates/nginx.conf.conf
+++ b/loadbalancer/templates/nginx.conf.conf
@@ -36,7 +36,7 @@ http {
     }
 
     upstream app {
-        server ${INTERNAL_DOMAIN}:5005;
+        server ${HOST_DOMAIN}:5005;
     }
     # Redirect localhost and the old altinn3local.no to the configured test domain
     server {

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -19,7 +19,7 @@ services:
       - NGINX_HOST=localhost
       - NGINX_PORT=80
       - TEST_DOMAIN=${TEST_DOMAIN:-local.altinn.cloud}
-      - INTERNAL_DOMAIN=host.containers.internal
+      - INTERNAL_DOMAIN=host.docker.internal
       - ALTINN3LOCAL_PORT=${ALTINN3LOCAL_PORT:-8080}
       - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx/
       - NGINX_ENVSUBST_TEMPLATE_SUFFIX=.conf

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -65,6 +65,7 @@ services:
       context: .
     environment:
       - DOTNET_ENVIRONMENT=Podman
+      - LOCAL_FRONTEND_PORT=${LOCAL_FRONTEND_PORT:-8080}
       - ASPNETCORE_URLS=http://*:5101/
       - GeneralSettings__BaseUrl=http://${TEST_DOMAIN:-local.altinn.cloud}:${ALTINN3LOCAL_PORT:-8080}
       - GeneralSettings__HostName=${TEST_DOMAIN:-local.altinn.cloud}

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -19,7 +19,7 @@ services:
       - NGINX_HOST=localhost
       - NGINX_PORT=80
       - TEST_DOMAIN=${TEST_DOMAIN:-local.altinn.cloud}
-      - INTERNAL_DOMAIN=host.docker.internal
+      - INTERNAL_DOMAIN=host.containers.internal
       - ALTINN3LOCAL_PORT=${ALTINN3LOCAL_PORT:-8080}
       - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx/
       - NGINX_ENVSUBST_TEMPLATE_SUFFIX=.conf

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -28,14 +28,10 @@ services:
         source: ./loadbalancer/templates/
         target: /etc/nginx/templates/
         read_only: true
-        bind:
-          selinux: Z
       - type: bind
         source: ./loadbalancer/www/
         target: /www/
         read_only: true
-        bind:
-          selinux: Z
 
 
   altinn_platform_pdf:
@@ -80,8 +76,6 @@ services:
         source: ./testdata/
         target: /testdata/
         read_only: true
-        bind:
-          selinux: Z
 
 volumes:
   AltinnPlatformLocal:

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -24,8 +24,18 @@ services:
       - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx/
       - NGINX_ENVSUBST_TEMPLATE_SUFFIX=.conf
     volumes:
-      - ./loadbalancer/templates/:/etc/nginx/templates/:z
-      - ./loadbalancer/www/:/www/:z
+      - type: bind
+        source: ./loadbalancer/templates/
+        target: /etc/nginx/templates/
+        read_only: true
+        bind:
+          selinux: Z
+      - type: bind
+        source: ./loadbalancer/www/
+        target: /www/
+        read_only: true
+        bind:
+          selinux: Z
 
 
   altinn_platform_pdf:
@@ -62,8 +72,16 @@ services:
       - GeneralSettings__BaseUrl=http://${TEST_DOMAIN:-local.altinn.cloud}:${ALTINN3LOCAL_PORT:-80}
       - GeneralSettings__HostName=${TEST_DOMAIN:-local.altinn.cloud}
     volumes:
-      - ./testdata:/testdata
-      - ${ALTINN3LOCALSTORAGE_PATH:-AltinnPlatformLocal}:/AltinnPlatformLocal
+      - type: volume
+        source: AltinnPlatformLocal
+        target: /AltinnPlatformLocal/
+        read_only: false
+      - type: bind
+        source: ./testdata/
+        target: /testdata/
+        read_only: true
+        bind:
+          selinux: Z
 
 volumes:
   AltinnPlatformLocal:

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -14,14 +14,14 @@ services:
         aliases:
           - ${TEST_DOMAIN:-local.altinn.cloud}
     ports:
-      - "${ALTINN3LOCAL_PORT:-8080}:80"
+      - "${ALTINN3LOCAL_PORT:-8000}:80"
     environment:
       - NGINX_HOST=localhost
       - NGINX_PORT=80
       - TEST_DOMAIN=${TEST_DOMAIN:-local.altinn.cloud}
       - HOST_DOMAIN=host.docker.internal
       - INTERNAL_DOMAIN=host.containers.internal
-      - ALTINN3LOCAL_PORT=${ALTINN3LOCAL_PORT:-8080}
+      - ALTINN3LOCAL_PORT=${ALTINN3LOCAL_PORT:-8000}
       - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx/
       - NGINX_ENVSUBST_TEMPLATE_SUFFIX=.conf
     volumes:
@@ -65,9 +65,8 @@ services:
       context: .
     environment:
       - DOTNET_ENVIRONMENT=Podman
-      - LOCAL_FRONTEND_PORT=${LOCAL_FRONTEND_PORT:-8080}
       - ASPNETCORE_URLS=http://*:5101/
-      - GeneralSettings__BaseUrl=http://${TEST_DOMAIN:-local.altinn.cloud}:${ALTINN3LOCAL_PORT:-8080}
+      - GeneralSettings__BaseUrl=http://${TEST_DOMAIN:-local.altinn.cloud}:${ALTINN3LOCAL_PORT:-8000}
       - GeneralSettings__HostName=${TEST_DOMAIN:-local.altinn.cloud}
     volumes:
       - type: volume

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -20,7 +20,7 @@ services:
       - NGINX_PORT=80
       - TEST_DOMAIN=${TEST_DOMAIN:-local.altinn.cloud}
       - INTERNAL_DOMAIN=host.containers.internal
-      - ALTINN3LOCAL_PORT=${ALTINN3LOCAL_PORT:-80}
+      - ALTINN3LOCAL_PORT=${ALTINN3LOCAL_PORT:-8080}
       - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx/
       - NGINX_ENVSUBST_TEMPLATE_SUFFIX=.conf
     volumes:
@@ -65,7 +65,7 @@ services:
     environment:
       - DOTNET_ENVIRONMENT=Podman
       - ASPNETCORE_URLS=http://*:5101/
-      - GeneralSettings__BaseUrl=http://${TEST_DOMAIN:-local.altinn.cloud}:${ALTINN3LOCAL_PORT:-80}
+      - GeneralSettings__BaseUrl=http://${TEST_DOMAIN:-local.altinn.cloud}:${ALTINN3LOCAL_PORT:-8080}
       - GeneralSettings__HostName=${TEST_DOMAIN:-local.altinn.cloud}
     volumes:
       - type: volume

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -5,12 +5,14 @@ networks:
     external: false
 
 services:
-  local.altinn.cloud:
+  localtest_loadbalancer:
     container_name: localtest-loadbalancer
     image: nginx:alpine-perl
     restart: always
     networks:
-      - altinntestlocal_network
+      altinntestlocal_network:
+        aliases:
+          - ${TEST_DOMAIN:-local.altinn.cloud}
     ports:
       - "${ALTINN3LOCAL_PORT:-8080}:80"
     environment:
@@ -22,8 +24,8 @@ services:
       - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx/
       - NGINX_ENVSUBST_TEMPLATE_SUFFIX=.conf
     volumes:
-      - ./loadbalancer/templates:/etc/nginx/templates/:ro
-      - ./loadbalancer/www:/www/:ro
+      - ./loadbalancer/templates/:/etc/nginx/templates/:z
+      - ./loadbalancer/www/:/www/:z
 
 
   altinn_platform_pdf:

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -19,6 +19,7 @@ services:
       - NGINX_HOST=localhost
       - NGINX_PORT=80
       - TEST_DOMAIN=${TEST_DOMAIN:-local.altinn.cloud}
+      - HOST_DOMAIN=host.docker.internal
       - INTERNAL_DOMAIN=host.containers.internal
       - ALTINN3LOCAL_PORT=${ALTINN3LOCAL_PORT:-8080}
       - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx/

--- a/scripts/OpenAppPortInHyperVFirewall.ps1
+++ b/scripts/OpenAppPortInHyperVFirewall.ps1
@@ -1,0 +1,7 @@
+$AppPort = 5005
+$NetFirewallHyperVName = '{40E0AC32-46A5-438A-A0B2-2B479E8F2E90}'
+
+Get-NetFirewallHyperVVMCreator 
+Get-NetFirewallHyperVVMSetting -PolicyStore ActiveStore -Name $NetFirewallHyperVName
+Get-NetFirewallHyperVRule -VMCreatorId $NetFirewallHyperVName
+New-NetFirewallHyperVRule -Name Altinn3App -DisplayName "Altinn 3 Application" -Direction Inbound -VMCreatorId $NetFirewallHyperVName -Protocol TCP -LocalPorts $AppPort

--- a/src/Configuration/LocalPlatformSettings.cs
+++ b/src/Configuration/LocalPlatformSettings.cs
@@ -41,6 +41,10 @@ namespace LocalTest.Configuration
             }
         }
 
+        public string LocalFrontendHostname { get; set; }
+        
+        public string LocalFrontendProtocol { get; set; } = "http";
+        
         /// <summary>
         /// Url for the local app when LocalAppMode == http
         /// <summary>

--- a/src/Controllers/FrontendVersionController.cs
+++ b/src/Controllers/FrontendVersionController.cs
@@ -2,13 +2,8 @@
 using System.Text.Json;
 
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Options;
-
-using LocalTest.Configuration;
 using LocalTest.Models;
-using LocalTest.Services.LocalApp.Interface;
-
-using LocalTest.Services.TestData;
+using LocalTest.Services.LocalFrontend.Interface;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Mvc.Rendering;
 
@@ -23,10 +18,9 @@ public class FrontendVersionController : Controller
     public static readonly string FRONTEND_URL_COOKIE_NAME = "frontendVersion";
 
     [HttpGet]
-    public async Task<ActionResult> Index([FromServices] HttpClient client)
+    public async Task<ActionResult> Index([FromServices] HttpClient client, [FromServices] ILocalFrontendService localFrontendService)
     {
         var versionFromCookie = HttpContext.Request.Cookies[FRONTEND_URL_COOKIE_NAME];
-        var localFrontednPort = Environment.GetEnvironmentVariable("LOCAL_FRONTEND_PORT") ?? "8080";
 
         var frontendVersion = new FrontendVersion()
         {
@@ -37,14 +31,20 @@ public class FrontendVersionController : Controller
                     {
                         Text = "Keep as is",
                         Value = "",
-                    },
-                    new ()
-                    {
-                        Text = $"localhost:{localFrontednPort} (local dev)",
-                        Value = $"http://localhost:{localFrontednPort}/"
                     }
                 }
         };
+        var groupLocalVersions = new SelectListGroup() { Name = "Frontend served from local dev server" };
+        var localFrontendPorts = await localFrontendService.GetLocalFrontendDevPorts();
+        foreach (var localPort in localFrontendPorts)
+        {
+            frontendVersion.Versions.Add(new SelectListItem()
+            {
+                Text = $"Local dev-server on port {localPort.Port} ({localPort.Branch} branch)",
+                Value = $"http://localhost:{localPort.Port}/",
+                Group = groupLocalVersions
+            });
+        }
         var cdnVersionsString = await client.GetStringAsync("https://altinncdn.no/toolkits/altinn-app-frontend/index.json");
         var groupCdnVersions = new SelectListGroup() { Name = "Specific version from cdn" };
         var versions = JsonSerializer.Deserialize<List<string>>(cdnVersionsString)!;

--- a/src/Controllers/FrontendVersionController.cs
+++ b/src/Controllers/FrontendVersionController.cs
@@ -26,6 +26,7 @@ public class FrontendVersionController : Controller
     public async Task<ActionResult> Index([FromServices] HttpClient client)
     {
         var versionFromCookie = HttpContext.Request.Cookies[FRONTEND_URL_COOKIE_NAME];
+        var localFrontednPort = Environment.GetEnvironmentVariable("LOCAL_FRONTEND_PORT") ?? "8080";
 
         var frontendVersion = new FrontendVersion()
         {
@@ -39,8 +40,8 @@ public class FrontendVersionController : Controller
                     },
                     new ()
                     {
-                        Text = "localhost:8080 (local dev)",
-                        Value = "http://localhost:8080/"
+                        Text = $"localhost:{localFrontednPort} (local dev)",
+                        Value = $"http://localhost:{localFrontednPort}/"
                     }
                 }
         };

--- a/src/Models/LocalFrontendInfo.cs
+++ b/src/Models/LocalFrontendInfo.cs
@@ -1,0 +1,7 @@
+namespace LocalTest.Models;
+
+public struct LocalFrontendInfo
+{
+    public string Port { get; init; }
+    public string Branch { get; init; }
+}

--- a/src/Services/LocalFrontend/Implementation/LocalFrontendService.cs
+++ b/src/Services/LocalFrontend/Implementation/LocalFrontendService.cs
@@ -1,0 +1,47 @@
+#nullable enable
+using LocalTest.Configuration;
+using LocalTest.Models;
+using LocalTest.Services.LocalFrontend.Interface;
+using Microsoft.Extensions.Options;
+
+namespace LocalTest.Services.LocalFrontend;
+
+public class LocalFrontendService: ILocalFrontendService
+{
+    private readonly HttpClient _httpClient;
+    private static readonly Range PortRange = 8080..8090;
+    private readonly string _localFrontedBaseUrl;
+
+    public LocalFrontendService(IHttpClientFactory httpClientFactory, IOptions<LocalPlatformSettings> localPlatformSettings)
+    {
+        _httpClient = httpClientFactory.CreateClient();
+        _localFrontedBaseUrl = $"{localPlatformSettings.Value.LocalFrontendProtocol}://{localPlatformSettings.Value.LocalFrontendHostname}";
+    }
+
+    public async Task<List<LocalFrontendInfo>> GetLocalFrontendDevPorts()
+    {
+        var ports = new List<LocalFrontendInfo>();
+        for (int i = PortRange.Start.Value; i < PortRange.End.Value; i++)
+        {
+            try
+            {
+                var response =
+                    await _httpClient.GetAsync($"{_localFrontedBaseUrl}:{i.ToString()}/");
+                if (response.Headers.TryGetValues("X-Altinn-Frontend-Branch", out var values))
+                {
+                    
+                    ports.Add(new LocalFrontendInfo()
+                    {
+                        Port = i.ToString(),
+                        Branch = values?.First() ?? "Unknown"
+                    });
+                }
+            }
+            catch(HttpRequestException)
+            {
+                
+            }
+        }
+        return ports;
+    }
+}

--- a/src/Services/LocalFrontend/Interface/ILocalFrontendService.cs
+++ b/src/Services/LocalFrontend/Interface/ILocalFrontendService.cs
@@ -1,0 +1,8 @@
+using LocalTest.Models;
+
+namespace LocalTest.Services.LocalFrontend.Interface;
+
+public interface ILocalFrontendService
+{
+    public Task<List<LocalFrontendInfo>> GetLocalFrontendDevPorts();
+}

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -36,6 +36,8 @@ using LocalTest.Services.Authorization.Interface;
 using LocalTest.Services.Events.Implementation;
 using LocalTest.Services.LocalApp.Implementation;
 using LocalTest.Services.LocalApp.Interface;
+using LocalTest.Services.LocalFrontend;
+using LocalTest.Services.LocalFrontend.Interface;
 using LocalTest.Services.Profile.Implementation;
 using LocalTest.Services.Profile.Interface;
 using LocalTest.Services.Register.Implementation;
@@ -199,6 +201,8 @@ namespace LocalTest
             {
                 services.AddTransient<ILocalApp, LocalAppFile>();
             }
+
+            services.AddTransient<ILocalFrontendService, LocalFrontendService>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/src/appsettings.Docker.json
+++ b/src/appsettings.Docker.json
@@ -1,6 +1,7 @@
 {
   "LocalPlatformSettings": {
     "LocalAppMode": "http",
+    "LocalFrontendHostname": "host.docker.internal",
     "LocalAppUrl": "http://host.docker.internal:5005",
     "LocalTestingStorageBasePath": "/AltinnPlatformLocal/",
     "LocalTestingStaticTestDataPath": "/testdata/"

--- a/src/appsettings.Podman.json
+++ b/src/appsettings.Podman.json
@@ -1,6 +1,7 @@
 {
   "LocalPlatformSettings": {
     "LocalAppMode": "http",
+    "LocalFrontendHostname": "host.docker.internal",
     "LocalAppUrl": "http://host.docker.internal:5005",
     "LocalTestingStorageBasePath": "/AltinnPlatformLocal/",
     "LocalTestingStaticTestDataPath": "/testdata/"

--- a/src/appsettings.Podman.json
+++ b/src/appsettings.Podman.json
@@ -1,7 +1,7 @@
 {
   "LocalPlatformSettings": {
     "LocalAppMode": "http",
-    "LocalAppUrl": "http://host.containers.internal:5005",
+    "LocalAppUrl": "http://host.docker.internal:5005",
     "LocalTestingStorageBasePath": "/AltinnPlatformLocal/",
     "LocalTestingStaticTestDataPath": "/testdata/"
   }

--- a/src/appsettings.json
+++ b/src/appsettings.json
@@ -40,6 +40,7 @@
   "AllowedHosts": "*",
   "LocalPlatformSettings": {
     "LocalAppMode": "file",
+    "LocalMachineHostName": "localhost",
     "LocalAppUrl": "http://localhost:5005",
     "LocalTestingStorageBasePath": "c:/AltinnPlatformLocal/",
     "AppRepositoryBasePath": "<Path to your repos folder where you have cloned the Altinn Studio application repositories>",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This started out as a fix for new apple silicone but got bigger as problems in other OSes was discovered.

* Fixed some issues that surfaced when trying to run app-localtest on an Mac-M3 machine.
* Also added some commands to help those running old versions of podman.
* Make localtest work with podman and compose on windows
* Provide a hack for fixing the problem with bind mounts giving permission denied inside containers

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
