### PR TITLE
Refine MailingAddress data for local test users

### DIFF
--- a/testdata/Register/Person/01017512345.json
+++ b/testdata/Register/Person/01017512345.json
@@ -6,7 +6,7 @@
   "LastName": "Nordmann",
   "TelephoneNumber": "12345678",
   "MobileNumber": "87654321",
-  "MailingAddress": "Blåbæreveien 7",
+  "MailingAddress": "Blåbæreveien 7 8450 Stokmarknes",
   "MailingPostalCode": "8450",
   "MailingPostalCity": "Stokmarknes",
   "AddressMunicipalNumber": "1866",

--- a/testdata/Register/Person/01039012345.json
+++ b/testdata/Register/Person/01039012345.json
@@ -6,7 +6,7 @@
   "LastName": "Salt",
   "TelephoneNumber": "12345678",
   "MobileNumber": "87654321",
-  "MailingAddress": "Grev Wedels Plass 9",
+  "MailingAddress": "Grev Wedels Plass 9 0157 Oslo",
   "MailingPostalCode": "0157",
   "MailingPostalCity": "Oslo",
   "AddressMunicipalNumber": "0301",

--- a/testdata/Register/Person/01899699552.json
+++ b/testdata/Register/Person/01899699552.json
@@ -1,20 +1,19 @@
 {
-    "SSN": "01899699552",
-    "Name": "Pengelens Partner",
-    "FirstName": "Pengelens",
-    "MiddleName": "",
-    "LastName": "Partner",
-    "TelephoneNumber": "12345678",
-    "MobileNumber": "87654321",
-    "MailingAddress": "Tuftekåsvegen 7",
-    "MailingPostalCode": "3920",
-    "MailingPostalCity": "PORSGRUNN",
-    "AddressMunicipalNumber": "3806",
-    "AddressMunicipalName": "Porsgrunn",
-    "AddressStreetName": "Tuftekåsvegen",
-    "AddressHouseNumber": "7",
-    "AddressHouseLetter": null,
-    "AddressPostalCode": "3920",
-    "AddressCity": "PORSGRUNN"
-  }
-  
+  "SSN": "01899699552",
+  "Name": "Pengelens Partner",
+  "FirstName": "Pengelens",
+  "MiddleName": "",
+  "LastName": "Partner",
+  "TelephoneNumber": "12345678",
+  "MobileNumber": "87654321",
+  "MailingAddress": "Tuftekåsvegen 7 3920 PORSGRUNN",
+  "MailingPostalCode": "3920",
+  "MailingPostalCity": "PORSGRUNN",
+  "AddressMunicipalNumber": "3806",
+  "AddressMunicipalName": "Porsgrunn",
+  "AddressStreetName": "Tuftekåsvegen",
+  "AddressHouseNumber": "7",
+  "AddressHouseLetter": null,
+  "AddressPostalCode": "3920",
+  "AddressCity": "PORSGRUNN"
+}

--- a/testdata/Register/Person/08829698278.json
+++ b/testdata/Register/Person/08829698278.json
@@ -1,20 +1,19 @@
 {
-    "SSN": "08829698278",
-    "Name": "Rik Forelder",
-    "FirstName": "Rik",
-    "MiddleName": "",
-    "LastName": "Forelder",
-    "TelephoneNumber": "12345678",
-    "MobileNumber": "87654321",
-    "MailingAddress": "Bjønnkamvegen 14",
-    "MailingPostalCode": "3735",
-    "MailingPostalCity": "SKIEN",
-    "AddressMunicipalNumber": "3807",
-    "AddressMunicipalName": "Skien",
-    "AddressStreetName": "Bjønnkamvegen",
-    "AddressHouseNumber": "14",
-    "AddressHouseLetter": null,
-    "AddressPostalCode": "3735",
-    "AddressCity": "SKIEN"
-  }
-  
+  "SSN": "08829698278",
+  "Name": "Rik Forelder",
+  "FirstName": "Rik",
+  "MiddleName": "",
+  "LastName": "Forelder",
+  "TelephoneNumber": "12345678",
+  "MobileNumber": "87654321",
+  "MailingAddress": "Bjønnkamvegen 14 3735 SKIEN",
+  "MailingPostalCode": "3735",
+  "MailingPostalCity": "SKIEN",
+  "AddressMunicipalNumber": "3807",
+  "AddressMunicipalName": "Skien",
+  "AddressStreetName": "Bjønnkamvegen",
+  "AddressHouseNumber": "14",
+  "AddressHouseLetter": null,
+  "AddressPostalCode": "3735",
+  "AddressCity": "SKIEN"
+}

--- a/testdata/Register/Person/17858296439.json
+++ b/testdata/Register/Person/17858296439.json
@@ -1,20 +1,19 @@
 {
-    "SSN": "17858296439",
-    "Name": "Gjentagende Forelder",
-    "FirstName": "Gjentagende",
-    "MiddleName": "",
-    "LastName": "Forelder",
-    "TelephoneNumber": "12345678",
-    "MobileNumber": "87654321",
-    "MailingAddress": "Ørneveien 36",
-    "MailingPostalCode": "1640",
-    "MailingPostalCity": "RÅDE",
-    "AddressMunicipalNumber": "3017",
-    "AddressMunicipalName": "Råde",
-    "AddressStreetName": "Ørneveien",
-    "AddressHouseNumber": "36",
-    "AddressHouseLetter": null,
-    "AddressPostalCode": "1640",
-    "AddressCity": "RÅDE"
-  }
-  
+  "SSN": "17858296439",
+  "Name": "Gjentagende Forelder",
+  "FirstName": "Gjentagende",
+  "MiddleName": "",
+  "LastName": "Forelder",
+  "TelephoneNumber": "12345678",
+  "MobileNumber": "87654321",
+  "MailingAddress": "Ørneveien 36 1640 RÅDE",
+  "MailingPostalCode": "1640",
+  "MailingPostalCity": "RÅDE",
+  "AddressMunicipalNumber": "3017",
+  "AddressMunicipalName": "Råde",
+  "AddressStreetName": "Ørneveien",
+  "AddressHouseNumber": "36",
+  "AddressHouseLetter": null,
+  "AddressPostalCode": "1640",
+  "AddressCity": "RÅDE"
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This pull request aims to standardize the "MailingAddress" field for local test users to align with the expected format in Altinn tt02 and production environments. Currently, the "MailingAddress" field for local test users consists of the concatenation of the AddressStreetName and AddressHouseNumber fields. 
However, to ensure consistency and minimize discrepancies between environments, it's proposed that the "MailingAddress" for all local test users should be composed of the AddressStreetName, AddressHouseNumber, AddressHouseLetter, MailingPostalCode and MailingPostalCity fields.

This change ensures that the prefill data displayed in the local test environment mirrors that of Altinn tt02 and production environments, thereby preventing unexpected discrepancies and reducing additional work for application developers.

## Related Issue(s)
- #{issue number}
- https://github.com/Altinn/altinn-register/issues/106

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
