### PR TITLE
PDF generator preview

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -40,9 +40,10 @@ services:
      - "5070:5070"
     extra_hosts:
       - "host.docker.internal:host-gateway"
+
   altinn_pdf_service:
     container_name: altinn-pdf-service
-    image: browserless/chrome:1-puppeteer-19.2.2
+    image: browserless/chrome:1-puppeteer-21.3.6
     restart: always
     networks:
       - altinntestlocal_network
@@ -50,6 +51,7 @@ services:
       - "5300:3000"
     extra_hosts:
       - "${TEST_DOMAIN:-local.altinn.cloud}:host-gateway"
+      - "host.containers.internal:host-gateway"
 
   altinn_localtest:
     container_name: localtest

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -44,9 +44,10 @@ services:
       - altinntestlocal_network
     ports:
      - "5070:5070"
+
   altinn_pdf_service:
     container_name: altinn-pdf-service
-    image: browserless/chrome:1-puppeteer-19.2.2
+    image: browserless/chrome:1-puppeteer-21.3.6
     restart: always
     networks:
       - altinntestlocal_network

--- a/src/Controllers/FrontendVersionController.cs
+++ b/src/Controllers/FrontendVersionController.cs
@@ -66,7 +66,7 @@ public class FrontendVersionController : Controller
         var options = new CookieOptions
         {
             Expires = DateTime.MaxValue,
-            HttpOnly = true,
+            HttpOnly = false,
         };
         ICookieManager cookieManager = new ChunkingCookieManager();
         if (string.IsNullOrWhiteSpace(frontendVersion.Version))

--- a/src/Controllers/HomeController.cs
+++ b/src/Controllers/HomeController.cs
@@ -344,7 +344,7 @@ namespace LocalTest.Controllers
             {
                 Name = "AltinnStudioRuntime",
                 SameSite = SameSiteMode.Lax,
-                HttpOnly = true,
+                HttpOnly = false,
                 SecurePolicy = CookieSecurePolicy.None,
                 IsEssential = true,
                 Domain = _generalSettings.Hostname,

--- a/src/Controllers/PDFPreviewController.cs
+++ b/src/Controllers/PDFPreviewController.cs
@@ -1,0 +1,14 @@
+#nullable enable
+
+using Microsoft.AspNetCore.Mvc;
+
+namespace LocalTest.Controllers;
+
+[Route("Home/[controller]/[action]")]
+public class PDFPreviewController : Controller
+{
+    public IActionResult Index()
+    {
+        return View();
+    }
+}

--- a/src/Views/PDFPreview/Index.cshtml
+++ b/src/Views/PDFPreview/Index.cshtml
@@ -1,0 +1,116 @@
+<div class="alert alert-info" role="alert">
+  Experimental preview using the local PDF generator.
+</div>
+
+
+<div id="missingParamsError" class="alert alert-error" style="display: none;" role="alert">
+  Query parameters org, app and instance are required.
+</div>
+
+<div id="missingCookieError" class="alert alert-error" style="display: none;" role="alert">
+  Authentication failed, please try the "Refresh authentication" button.
+</div>
+
+<div id="failedError" class="alert alert-error" style="display: none;" role="alert">
+  PDF generation failed, refresh to try again.
+</div>
+
+<iframe id="pdfIframe" title="" style="display: none; width: 100%; height: 100vh; margin-bottom: -16px"></iframe>
+
+<script>
+  function generatePDF() {
+    let params = new URLSearchParams(window.location.search);
+    let org = params.get('org');
+    let app = params.get('app');
+    let instance = params.get('instance');
+    let language = params.get('lang') ?? 'nb';
+
+    if (!org || !app || !instance){
+      document.querySelector('#missingParamsError').style.display = 'block';
+      return;
+    }
+
+    let cookies = document.cookie
+    .split(';')
+    .map(v => v.split('='))
+    .reduce((acc, v) => {
+      acc[decodeURIComponent(v[0].trim())] = decodeURIComponent(v[1].trim());
+      return acc;
+    }, {});
+
+    let token = cookies['AltinnStudioRuntime'];
+    let partyId = cookies['AltinnPartyId'];
+    let frontendVersion = cookies['frontendVersion'];
+
+    if (!token || !partyId) {
+      document.querySelector('#missingCookieError').style.display = 'block';
+      return;
+    }
+
+    let pdfGeneratorUrl = `http://${window.location.host}/pdfservice/pdf`;
+    let pdfUrl = `http://local.altinn.cloud/${org}/${app}/#/instance/${instance}?pdf=1&lang=${language}`;
+    let pdfCookies = [
+      {
+        name: 'AltinnStudioRuntime',
+        domain: 'local.altinn.cloud',
+        sameSite: 'Lax',
+        value: token
+      },
+      {
+        name: 'AltinnPartyId',
+        domain: 'local.altinn.cloud',
+        sameSite: 'Lax',
+        value: partyId
+      }
+    ];
+
+    if (frontendVersion) {
+      frontendVersion = frontendVersion.replace("localhost", "host.containers.internal");
+      pdfCookies = [{
+        name: 'frontendVersion',
+        domain: 'local.altinn.cloud',
+        value: frontendVersion
+      }, ...pdfCookies];
+    }
+
+    let requestBody = {
+      url: pdfUrl,
+      cookies: pdfCookies,
+      waitFor: "#readyForPrint",
+        setJavaScriptEnabled: true,
+        options: {
+          displayHeaderFooter: false,
+          printBackground: true,
+          format: "A4",
+          margin: {
+            top: "0.75in",
+            left: "0.75in",
+            bottom: "0.75in",
+            right: "0.75in"
+          }
+        }
+      };
+
+    fetch(pdfGeneratorUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(requestBody),
+    })
+    .then(response => response.blob())
+    .then(blob => {
+      let objectUrl = URL.createObjectURL(blob);
+      let pdfIframe = document.querySelector('#pdfIframe');
+
+      pdfIframe.src = objectUrl;
+      pdfIframe.style.display = 'block';
+    })
+    .catch(() => {
+      document.querySelector('#failedError').style.display = 'block';
+      return;
+    });
+  }
+
+  generatePDF();
+</script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This allows you to use the local PDF generator in docker/podman to generate a PDF preview for an app. This has some benefits:
- Works in any browser, since it does not rely on the clients browser to print the PDF
- Gets exactly the same results as when the app generates PDF.
  - It uses the same options as the default `PdfGeneratorRequestOptions` in app-lib. When using print-to-pdf in chrome, the default margins etc. do not match
- Uses the `frontendVersion` cookie to use the same version. Works with localhost as well by rewriting `localhost` -> `host.containers.internal` before sending it along.

It needs queryParameters for the `org`, `app`, `instance`, and `lang`. App-frontend can easily set these correctly: https://github.com/Altinn/app-frontend-react/pull/1794

For now, you can just refresh the page to regenerate the PDF.

**Note**: For this to work it requires changing some cookies to no longer have `httpOnly`, since the cookies need to be sent along to the PDF generator in the request body.

<img width="1366" alt="image" src="https://github.com/Altinn/app-localtest/assets/47412359/e7cdcfce-36bb-4029-8d0d-8ad915af1a17">

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
