### PR TITLE
Podman: Mounting volumes with `z` to work around permission issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,10 @@ podman-compose-start-localtest:
 .PHONY: podman-compose-stop-localtest
 podman-compose-stop-localtest:
 	podman-compose --file podman-compose.yml down
+
+.PHONY: podman-selinux-bind-hack
+podman-selinux-bind-hack:
+	@echo "Running best effort commands to make bind mounts work on Apple Silicon and Linux with podman. Dirty hack until actual issue is located and fixed."
+	podman container run -v ./testdata/:/testdata/:Z --rm -it --entrypoint cat nginx:alpine-perl /testdata/authorization/claims/1337.json > /dev/null
+	podman container run -v ./loadbalancer/templates/:/testdata/:Z --rm -it --entrypoint cat nginx:alpine-perl /testdata/nginx.conf.conf > /dev/null
+	podman container run -v ./loadbalancer/www/:/testdata/:Z --rm -it --entrypoint cat nginx:alpine-perl /testdata/502App.html > /dev/null

--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,3 @@ podman-compose-start-localtest:
 .PHONY: podman-compose-stop-localtest
 podman-compose-stop-localtest:
 	podman-compose --file podman-compose.yml down
-		
-
-.PHONY: podman-selinux-bind-hack
-podman-selinux-bind-hack:
-	@echo "Running best effort commands to make bind mounts work on Apple Silicon and Linux with podman. Dirty hack until actual issue is located and fixed."
-	podman container run -v ./testdata/:/testdata/:Z --rm -it --entrypoint cat nginx:alpine-perl /testdata/authorization/claims/1337.json > /dev/null
-	podman container run -v ./loadbalancer/templates/:/testdata/:Z --rm -it --entrypoint cat nginx:alpine-perl /testdata/nginx.conf.conf > /dev/null
-	podman container run -v ./loadbalancer/www/:/testdata/:Z --rm -it --entrypoint cat nginx:alpine-perl /testdata/502App.html > /dev/null

--- a/README.md
+++ b/README.md
@@ -218,22 +218,6 @@ This would be required if your app requires a role which none of the test users 
 
 ### Known issues
 
-#### Bind mounts folders gives permission denied. Nginx returns default page
-
-On some nix systems you might experience problems with the bind mounts used by the containers. If you get the default nginx page when trying to access local.altinn.cloud this might be the case.
-
-To verify this you can run the following command:
-
-```shell
-podman container exec -it localtest-loadbalancer cat /etc/nginx/templates/nginx.conf.conf
-```
-
-if you get a permission denied message this verifies that the bind mount is not working. A best effort fix for this is to run the following command:
-
-```shell
-make podman-selinux-bind-hack
-```
-
 #### Localtest reports that the app is not running even though it is
 
 If localtest and you app is running, but localtest reports that the app is not running, it might be that the port is not open in the firewall.

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -64,10 +64,7 @@ services:
       - GeneralSettings__HostName=${TEST_DOMAIN:-local.altinn.cloud}
     volumes:
       - ./testdata/:/testdata/:ro,z
-      - type: volume
-        source: AltinnPlatformLocal
-        target: /AltinnPlatformLocal/
-        read_only: false
+      - AltinnPlatformLocal:/AltinnPlatformLocal/:rw
 
 volumes:
   AltinnPlatformLocal:

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -25,15 +25,8 @@ services:
       - NGINX_ENVSUBST_OUTPUT_DIR=/etc/nginx/
       - NGINX_ENVSUBST_TEMPLATE_SUFFIX=.conf
     volumes:
-      - type: bind
-        source: ./loadbalancer/templates/
-        target: /etc/nginx/templates/
-        read_only: true
-      - type: bind
-        source: ./loadbalancer/www/
-        target: /www/
-        read_only: true
-
+      - ./loadbalancer/templates/:/etc/nginx/templates/:ro,z
+      - ./loadbalancer/www/:/www/:ro,z
 
   altinn_platform_pdf:
     container_name: altinn-pdf
@@ -44,6 +37,7 @@ services:
       - altinntestlocal_network
     ports:
      - "5070:5070"
+
   altinn_pdf_service:
     container_name: altinn-pdf-service
     image: browserless/chrome:1-puppeteer-19.2.2
@@ -69,14 +63,11 @@ services:
       - GeneralSettings__BaseUrl=http://${TEST_DOMAIN:-local.altinn.cloud}:${ALTINN3LOCAL_PORT:-8000}
       - GeneralSettings__HostName=${TEST_DOMAIN:-local.altinn.cloud}
     volumes:
+      - ./testdata/:/testdata/:ro,z
       - type: volume
         source: AltinnPlatformLocal
         target: /AltinnPlatformLocal/
         read_only: false
-      - type: bind
-        source: ./testdata/
-        target: /testdata/
-        read_only: true
 
 volumes:
   AltinnPlatformLocal:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
