### PR TITLE
Support any version in Index.cshtml when replacing frontend version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.6'
+version: "3.6"
 
 networks:
   altinntestlocal_network:
@@ -7,7 +7,11 @@ networks:
 services:
   localtest_loadbalancer:
     container_name: localtest-loadbalancer
-    image: nginx:alpine-perl
+    image: localtest-loadbalancer:latest
+    build:
+      context: ./loadbalancer
+      args:
+        NGINX_VERSION: 1.25.3
     restart: always
     networks:
       - altinntestlocal_network
@@ -28,7 +32,6 @@ services:
       - ./loadbalancer/templates:/etc/nginx/templates/:ro
       - ./loadbalancer/www:/www/:ro
 
-
   altinn_platform_pdf:
     container_name: altinn-pdf
     platform: linux/amd64
@@ -37,7 +40,7 @@ services:
     networks:
       - altinntestlocal_network
     ports:
-     - "5070:5070"
+      - "5070:5070"
     extra_hosts:
       - "host.docker.internal:host-gateway"
   altinn_pdf_service:

--- a/loadbalancer/Dockerfile
+++ b/loadbalancer/Dockerfile
@@ -1,0 +1,45 @@
+# Based on: https://github.com/tofran/nginx-with-substitutions-filter-docker/blob/main/Dockerfile
+
+ARG NGINX_VERSION
+
+FROM nginx:${NGINX_VERSION}-alpine-perl AS builder
+
+RUN apk add --no-cache --virtual .build-deps \
+      alpine-sdk \
+      bash \
+      findutils \
+      gcc \
+      gd-dev \
+      geoip-dev \
+      libc-dev \
+      libedit-dev \
+      libxslt-dev \
+      linux-headers \
+      make \
+      openssl-dev \
+      pcre2-dev \
+      perl-dev \
+      zlib-dev
+
+RUN mkdir -p /usr/src \
+    && wget https://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz -O nginx.tar.gz \
+    && wget https://github.com/yaoweibin/ngx_http_substitutions_filter_module/archive/master.tar.gz -O nginx_substitutions_filter.tar.gz \
+    && tar -zxC /usr/src -f nginx.tar.gz \
+    && tar -zxC /usr/src -f nginx_substitutions_filter.tar.gz  \
+    && rm nginx.tar.gz \
+    && rm nginx_substitutions_filter.tar.gz \
+    && cd /usr/src/nginx-$NGINX_VERSION \
+    && bash -c 'set -eux && eval ./configure $(nginx -V 2>&1 | sed -n -e "s/^.*configure arguments: //p") --add-dynamic-module=/usr/src/ngx_http_substitutions_filter_module-master' \
+    && make \
+    && make install
+
+FROM nginx:${NGINX_VERSION}-alpine-perl
+
+COPY --from=builder /usr/lib/nginx/modules/ngx_http_subs_filter_module.so /usr/lib/nginx/modules/ngx_http_subs_filter_module.so
+
+RUN sed -i '1iload_module /usr/lib/nginx/modules/ngx_http_subs_filter_module.so;\n' /etc/nginx/nginx.conf
+
+EXPOSE 80
+STOPSIGNAL SIGTERM
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/loadbalancer/templates/nginx.conf.conf
+++ b/loadbalancer/templates/nginx.conf.conf
@@ -1,4 +1,5 @@
 load_module /etc/nginx/modules/ngx_http_perl_module.so;
+load_module /usr/lib/nginx/modules/ngx_http_subs_filter_module.so;
 
 worker_processes 1;
 
@@ -12,13 +13,25 @@ http {
     perl_set $LOCAL_SUB_FILTER 'sub {
       my $r = shift;
       my $cookie = $r->header_in("cookie");
-      my $url = $1 if ($cookie =~ /.*frontendVersion=(http.*?);/);
+      my $url = $1 if ($cookie =~ /.*frontendVersion=(http[^;]+)(;|$)/);
       if($url)
       {
         $uri = $r->unescape($url);
         return $uri;
       }
-      return "https://altinncdn.no/toolkits/altinn-app-frontend/3/"
+      return "";
+    }';
+
+    # If no cookie is set, bypass the sub_filter
+    perl_set $SUB_FILTER_BYPASS 'sub {
+      my $r = shift;
+      my $cookie = $r->header_in("cookie");
+      my $url = $1 if ($cookie =~ /.*frontendVersion=(http[^;]+)(;|$)/);
+      if($url)
+      {
+        return "0";
+      }
+      return "1";
     }';
 
     client_max_body_size 50M;
@@ -75,8 +88,10 @@ http {
 
     location / {
         #Support using Local js, when a cookie value is set
-        sub_filter_once off;
-        sub_filter 'https://altinncdn.no/toolkits/altinn-app-frontend/3/' $LOCAL_SUB_FILTER;
+        subs_filter_types text/html;
+        subs_filter http.+\/(altinn-app-frontend\.(js|css)) $LOCAL_SUB_FILTER$1 gr;
+        subs_filter_bypass $SUB_FILTER_BYPASS;
+
         proxy_pass          http://app/;
         error_page 502 /502App.html;
         proxy_cookie_domain altinn3local.no local.altinn.cloud;

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -1,4 +1,4 @@
-version: '3.6'
+version: "3.6"
 
 networks:
   altinntestlocal_network:
@@ -7,7 +7,11 @@ networks:
 services:
   localtest_loadbalancer:
     container_name: localtest-loadbalancer
-    image: nginx:alpine-perl
+    image: localtest-loadbalancer:latest
+    build:
+      context: ./loadbalancer
+      args:
+        NGINX_VERSION: 1.25.3
     restart: always
     networks:
       altinntestlocal_network:
@@ -34,7 +38,6 @@ services:
         target: /www/
         read_only: true
 
-
   altinn_platform_pdf:
     container_name: altinn-pdf
     platform: linux/amd64
@@ -43,7 +46,7 @@ services:
     networks:
       - altinntestlocal_network
     ports:
-     - "5070:5070"
+      - "5070:5070"
   altinn_pdf_service:
     container_name: altinn-pdf-service
     image: browserless/chrome:1-puppeteer-19.2.2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This adds support for replacing any frontend version in `Index.cshtml`. Unfortunately, this was a bit more involved than expected, since the standard `sub_filter` only allows simple string substitution and not regex. To get around this, I needed the third-party [ngx_http_substitutions_filter_module](https://www.nginx.com/resources/wiki/modules/substitutions/). This required some modifications to the standard docker image for nginx which I based on [this](https://github.com/tofran/nginx-with-substitutions-filter-docker).

This also fixes a bug where it would not find the frontendVersion cookie if it was the last one in the `Cookies` header. This is because it previously required the string to end with a `;`. This probably explains the flakyness I myself have experienced with this before.

## Related Issue(s)
- closes #77 

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)