### PR TITLE
Update browserless and add extra_hosts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.6'
+version: "3.6"
 
 networks:
   altinntestlocal_network:
@@ -28,7 +28,6 @@ services:
       - ./loadbalancer/templates:/etc/nginx/templates/:ro
       - ./loadbalancer/www:/www/:ro
 
-
   altinn_platform_pdf:
     container_name: altinn-pdf
     platform: linux/amd64
@@ -37,12 +36,13 @@ services:
     networks:
       - altinntestlocal_network
     ports:
-     - "5070:5070"
+      - "5070:5070"
     extra_hosts:
       - "host.docker.internal:host-gateway"
+
   altinn_pdf_service:
     container_name: altinn-pdf-service
-    image: browserless/chrome:1-puppeteer-19.2.2
+    image: browserless/chrome:1-puppeteer-21.3.6
     restart: always
     networks:
       - altinntestlocal_network
@@ -50,6 +50,7 @@ services:
       - "5300:3000"
     extra_hosts:
       - "${TEST_DOMAIN:-local.altinn.cloud}:host-gateway"
+      - "host.containers.internal:host-gateway"
 
   altinn_localtest:
     container_name: localtest

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -1,4 +1,4 @@
-version: '3.6'
+version: "3.6"
 
 networks:
   altinntestlocal_network:
@@ -34,7 +34,6 @@ services:
         target: /www/
         read_only: true
 
-
   altinn_platform_pdf:
     container_name: altinn-pdf
     platform: linux/amd64
@@ -43,10 +42,11 @@ services:
     networks:
       - altinntestlocal_network
     ports:
-     - "5070:5070"
+      - "5070:5070"
+
   altinn_pdf_service:
     container_name: altinn-pdf-service
-    image: browserless/chrome:1-puppeteer-19.2.2
+    image: browserless/chrome:1-puppeteer-21.3.6
     restart: always
     networks:
       - altinntestlocal_network


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

- This updates browserless to the latest version that works on both x84 and arm. The version in tt02 and prod is slightly newer than this (21.4.1).
- Also adds `hosts.containers.internal` to docker-compose PDF generator so the same local hostname can be used for both podman and docker for local PDF generator testing.

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/pull/432

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
