### PR TITLE
Don't keep file streams open

### DIFF
--- a/src/Services/Storage/Implementation/DataRepository.cs
+++ b/src/Services/Storage/Implementation/DataRepository.cs
@@ -212,7 +212,7 @@ namespace LocalTest.Services.Storage.Implementation
 
         private static async Task<string> ReadFileAsString(string path)
         {
-            Stream stream = await ReadFileAsStream(path);
+            using Stream stream = await ReadFileAsStream(path);
             using StreamReader reader = new StreamReader(stream);
             return await reader.ReadToEndAsync();
         }

--- a/src/Services/Storage/Implementation/DataService.cs
+++ b/src/Services/Storage/Implementation/DataService.cs
@@ -42,7 +42,7 @@ namespace Altinn.Platform.Storage.Services
                 return (null, new ServiceError(404, $"DataElement not found, dataElementId: {dataElementId}"));
             }
 
-            Stream filestream = await _dataRepository.ReadDataFromStorage(org, dataElement.BlobStoragePath);
+            using Stream filestream = await _dataRepository.ReadDataFromStorage(org, dataElement.BlobStoragePath);
             if (filestream == null || !filestream.CanRead)
             {
                 return (null, new ServiceError(404, $"Failed reading file, dataElementId: {dataElementId}"));


### PR DESCRIPTION
There have been reported issues with the new PATCH endpoint in localtest with error messages like

```
fail: Altinn.App.Api.Controllers.DataController[0]
      Unable to update data element 57abc10b-d54d-4fd8-bcee-79876d3feaee for instance 500000/8125c8ac-7624-44f3-8429-37ab780aa86c
      Altinn.App.Core.Helpers.PlatformHttpException: 500 - Internal Server Error - System.IO.IOException: The process cannot access the file '/AltinnPlatformLocal/blobs/krt/krt-1185a-1/8125c8ac-7624-44f3-8429-37ab780aa86c/data/57abc10b-d54d-4fd8-bcee-79876d3feaee' because it is being used by another process.
```

This is likely caused by not closing streams.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
