### PR TITLE
Fix for local testing for `altinn-receipt`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,6 +71,8 @@ services:
       - ASPNETCORE_URLS=http://*:5101/
       - GeneralSettings__BaseUrl=http://${TEST_DOMAIN:-local.altinn.cloud}:${ALTINN3LOCAL_PORT:-80}
       - GeneralSettings__HostName=${TEST_DOMAIN:-local.altinn.cloud}
+      - PlatformSettings__ApiAuthorizationEndpoint=http://host.docker.internal:5101/authorization/api/v1/
+      - AuthnGeneralSettings__PlatformEndpoint=http://host.docker.internal:5101/
     volumes:
       - ./testdata:/testdata
       - ${ALTINN3LOCALSTORAGE_PATH:-AltinnPlatformLocal}:/AltinnPlatformLocal


### PR DESCRIPTION
Fix for local testing for `altinn-receipt`

## Description
While this solution addresses local testing for `altinn-receipt`, I'm open to exploring alternative methods that don't involve modifying the `docker-compose.yml` file directly. If you have any ideas or suggestions, please provide your input here. 🙂 

## Related Issue(s)
- https://github.com/Altinn/altinn-receipt/issues/253
- https://github.com/Altinn/altinn-receipt/pull/265

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
