### PR TITLE
Fixes for app testing with localtest in podman

### DIFF
--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -211,7 +211,7 @@ namespace LocalTest
             IWebHostEnvironment env,
             IOptions<LocalPlatformSettings> localPlatformSettings)
         {
-            if (env.IsDevelopment() || env.IsEnvironment("docker"))
+            if (env.IsDevelopment() || env.IsEnvironment("docker") || env.IsEnvironment("podman"))
             {
                 app.UseDeveloperExceptionPage();
 

--- a/src/appsettings.Podman.json
+++ b/src/appsettings.Podman.json
@@ -1,4 +1,7 @@
 {
+  "AuthnGeneralSettings": {
+    "PlatformEndpoint": "http://local.altinn.cloud:5101/"
+  },
   "LocalPlatformSettings": {
     "LocalAppMode": "http",
     "LocalFrontendHostname": "host.docker.internal",

--- a/src/appsettings.Podman.json
+++ b/src/appsettings.Podman.json
@@ -1,6 +1,6 @@
 {
   "AuthnGeneralSettings": {
-    "PlatformEndpoint": "http://local.altinn.cloud:5101/"
+    "PlatformEndpoint": "http://localhost:5101/"
   },
   "LocalPlatformSettings": {
     "LocalAppMode": "http",


### PR DESCRIPTION
## Description
I ran into a problem testing an app locally, with localtest running in Podman. The issue is that the endpoint for the openid connect configuration generates a URL to the JWK that the app is unable to reach.

![image](https://github.com/Altinn/app-localtest/assets/2217340/6f350140-a0ae-45a2-887c-abaad46787c7)

Could I have solved it in a different way? Changing settings in my app?

Configuration in my app points to localhost:5101 for all platform endpoints. These are default settings for a new app and they seems to work. The issue starts when localtest returns a generated URL in a response like for the openid connect configuration.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
