### PR TITLE
Set FileScanResult to Clean in localtest.

### DIFF
--- a/src/Controllers/Storage/DataController.cs
+++ b/src/Controllers/Storage/DataController.cs
@@ -272,7 +272,11 @@ namespace Altinn.Platform.Storage.Controllers
             Stream theStream = streamAndDataElement.Stream;
             DataElement newData = streamAndDataElement.DataElement;
 
+#if LOCALTEST
+            newData.FileScanResult = dataTypeDefinition.EnableFileScan ? FileScanResult.Clean : FileScanResult.NotApplicable;
+#else
             newData.FileScanResult = dataTypeDefinition.EnableFileScan ? FileScanResult.Pending : FileScanResult.NotApplicable;
+#endif
 
             if (theStream == null)
             {
@@ -404,7 +408,11 @@ namespace Altinn.Platform.Storage.Controllers
 
             if (blobSize > 0)
             {
+#if LOCALTEST
+                FileScanResult scanResult = dataTypeDefinition.EnableFileScan ? FileScanResult.Clean : FileScanResult.NotApplicable;
+#else
                 FileScanResult scanResult = dataTypeDefinition.EnableFileScan ? FileScanResult.Pending : FileScanResult.NotApplicable;
+#endif
 
                 updatedProperties.Add("/fileScanResult", scanResult);
 


### PR DESCRIPTION
A better approach would be to wait 1 minute before setting it to clean, and provide some sort of known test file that always is `Infected`, but this simple fix makes it possible to use EnableFileScan locally.

The current code comes from https://github.com/Altinn/app-localtest/pull/46 which does not seem to deliberately force localtest users to not enable filescan.