### PR TITLE
Pass `SignRequest.GeneratedFromTask` to `DataElementHelper.CreateDataElement`

### DIFF
--- a/src/LocalTest.csproj
+++ b/src/LocalTest.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="Altinn.Authorization.ABAC" Version="0.0.8" />
     <PackageReference Include="Altinn.Common.PEP" Version="3.0.0" />
     <PackageReference Include="Altinn.Platform.Models" Version="1.4.0" />
-    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.22.0" />
+    <PackageReference Include="Altinn.Platform.Storage.Interface" Version="3.25.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
     <PackageReference Include="FluentValidation" Version="11.8.0" />
     <PackageReference Include="JWTCookieAuthentication" Version="2.4.2" />

--- a/src/Services/Storage/Implementation/InstanceService.cs
+++ b/src/Services/Storage/Implementation/InstanceService.cs
@@ -75,7 +75,7 @@ namespace Altinn.Platform.Storage.Services
                 $"{signRequest.SignatureDocumentDataType}.json",
                 0,
                 userId.ToString(),
-                instance.Process.CurrentTask?.ElementId);
+                signRequest.GeneratedFromTask);
 
             signDocument.Id = dataElement.Id;
 

--- a/src/Services/Storage/Implementation/InstanceService.cs
+++ b/src/Services/Storage/Implementation/InstanceService.cs
@@ -75,7 +75,7 @@ namespace Altinn.Platform.Storage.Services
                 $"{signRequest.SignatureDocumentDataType}.json",
                 0,
                 userId.ToString(),
-                null);
+                instance.Process.CurrentTask?.ElementId);
 
             signDocument.Id = dataElement.Id;
 


### PR DESCRIPTION
## Description
Unify specific `altinn-storage` change with implementation in `app-localtest`.

This change is required for an `app-lib-dotnet` patch related to duplicate signatures (PR below). 

## Test results
✅ Using the test setup [described here](https://github.com/Altinn/app-lib-dotnet/pull/617), it has been confirmed that _existing_ behavior is preserved with the current builds of `app-lib-dotnet` and that _new_ expected behavior is achieved with [the proposed new feature in app-lib-dotnet](https://github.com/Altinn/app-lib-dotnet/pull/617).

## Related PRs
- https://github.com/Altinn/altinn-storage/pull/392
- https://github.com/Altinn/altinn-storage/pull/404
- https://github.com/Altinn/app-lib-dotnet/pull/617
