### PR TITLE
Nginx refused to boot when a hostname was invalid

### DIFF
--- a/loadbalancer/templates/nginx.conf.conf
+++ b/loadbalancer/templates/nginx.conf.conf
@@ -150,14 +150,16 @@ http {
         }
 
         location /grafana/ {
-            resolver 127.0.0.11;
+            resolver 127.0.0.11; # Docker DNS resolver
+            # We use a variable here to avoid Nginx crashing for when the container isn't running
             set $upstream http://monitoring_grafana:3000;
             proxy_pass $upstream;
         }
 
         # Proxy Grafana Live WebSocket connections.
         location /grafana/api/live/ {
-            resolver 127.0.0.11;
+            resolver 127.0.0.11; # Docker DNS resolver
+            # We use a variable here to avoid Nginx crashing for when the container isn't running
             set $upstream http://monitoring_grafana:3000;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;

--- a/loadbalancer/templates/nginx.conf.conf
+++ b/loadbalancer/templates/nginx.conf.conf
@@ -150,12 +150,14 @@ http {
         }
 
         location /grafana/ {
+            resolver 127.0.0.11;
             set $upstream http://monitoring_grafana:3000;
             proxy_pass $upstream;
         }
 
         # Proxy Grafana Live WebSocket connections.
         location /grafana/api/live/ {
+            resolver 127.0.0.11;
             set $upstream http://monitoring_grafana:3000;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;

--- a/loadbalancer/templates/nginx.conf.conf
+++ b/loadbalancer/templates/nginx.conf.conf
@@ -74,10 +74,6 @@ http {
         server ${INTERNAL_DOMAIN}:5117;
     }
 
-    upstream grafana {
-        server monitoring_grafana:3000;
-    }
-
     server {
         listen 80 default_server;
         server_name ${TEST_DOMAIN};
@@ -154,15 +150,17 @@ http {
         }
 
         location /grafana/ {
-            proxy_pass http://grafana;
+            set $upstream http://monitoring_grafana:3000;
+            proxy_pass $upstream;
         }
 
         # Proxy Grafana Live WebSocket connections.
         location /grafana/api/live/ {
+            set $upstream http://monitoring_grafana:3000;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
-            proxy_pass http://grafana;
+            proxy_pass $upstream;
         }
     }
 }


### PR DESCRIPTION
## Description
Nginx refused to boot when a hostname was invalid
Letting the upstream be a variable makes Nginx not crash on startup, and it will resolve dynamically

## Related Issue(s)
- #97

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
