### PR TITLE
Workaround for frontend-version page not working in podman v5

### DIFF
--- a/src/Services/LocalFrontend/Implementation/LocalFrontendService.cs
+++ b/src/Services/LocalFrontend/Implementation/LocalFrontendService.cs
@@ -3,45 +3,52 @@ using LocalTest.Configuration;
 using LocalTest.Models;
 using LocalTest.Services.LocalFrontend.Interface;
 using Microsoft.Extensions.Options;
+using static System.Linq.Enumerable;
 
 namespace LocalTest.Services.LocalFrontend;
 
-public class LocalFrontendService: ILocalFrontendService
+public class LocalFrontendService : ILocalFrontendService
 {
     private readonly HttpClient _httpClient;
     private static readonly Range PortRange = 8080..8090;
     private readonly string _localFrontedBaseUrl;
 
-    public LocalFrontendService(IHttpClientFactory httpClientFactory, IOptions<LocalPlatformSettings> localPlatformSettings)
+    public LocalFrontendService(
+        IHttpClientFactory httpClientFactory,
+        IOptions<LocalPlatformSettings> localPlatformSettings
+    )
     {
         _httpClient = httpClientFactory.CreateClient();
-        _localFrontedBaseUrl = $"{localPlatformSettings.Value.LocalFrontendProtocol}://{localPlatformSettings.Value.LocalFrontendHostname}";
+        _httpClient.Timeout = TimeSpan.FromMilliseconds(500);
+        _localFrontedBaseUrl =
+            $"{localPlatformSettings.Value.LocalFrontendProtocol}://{localPlatformSettings.Value.LocalFrontendHostname}";
     }
 
     public async Task<List<LocalFrontendInfo>> GetLocalFrontendDevPorts()
     {
-        var ports = new List<LocalFrontendInfo>();
-        for (int i = PortRange.Start.Value; i < PortRange.End.Value; i++)
+        var tasks = Range(PortRange.Start.Value, PortRange.End.Value).Select(port => TestFrontendDevPort(port));
+        var result = await Task.WhenAll(tasks);
+        return result.Where(x => x != null).Select(x => x!.Value).ToList();
+    }
+
+    private async Task<LocalFrontendInfo?> TestFrontendDevPort(int port)
+    {
+        try
         {
-            try
+            var response = await _httpClient.GetAsync($"{_localFrontedBaseUrl}:{port.ToString()}/");
+            if (response.Headers.TryGetValues("X-Altinn-Frontend-Branch", out var values))
             {
-                var response =
-                    await _httpClient.GetAsync($"{_localFrontedBaseUrl}:{i.ToString()}/");
-                if (response.Headers.TryGetValues("X-Altinn-Frontend-Branch", out var values))
+                return new LocalFrontendInfo()
                 {
-                    
-                    ports.Add(new LocalFrontendInfo()
-                    {
-                        Port = i.ToString(),
-                        Branch = values?.First() ?? "Unknown"
-                    });
-                }
-            }
-            catch(HttpRequestException)
-            {
-                
+                    Port = port.ToString(),
+                    Branch = values?.First() ?? "Unknown"
+                };
             }
         }
-        return ports;
+        catch (TaskCanceledException) { }
+        catch (HttpRequestException) { }
+
+        return null;
     }
 }
+


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Ever since upgrading to podman v5 I have had trouble with the "Pick frontend version" page taking forever and eventually timing out. I have waited for a couple of updates with the hope that it would resolve itself, but seeing as this is still an issue for me in podman v5.1 I have made this workaround.

The issue seems to be that when trying to connect to a port on `host.docker.internal` that does not have a server running it just tries to connect forever until eventually timing out after 100 seconds, throwing a `TaskCanceledException` which is not caught in `main` so the page eventually fails to load. I have not figured out why the requests don't simply fail instantly. To work around this problem I catch the `TaskCanceledException`, use a very low timeout for the `HttpClient`, and run the requests in parallel so that it only takes half a second to fail all of the other requests where a frontend server is not running.

If someone else uses podman v5 and don't have this issue then maybe its just my machine, and if we figure it out we could close this.

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
