### PR TITLE
Fix GetInstances async postprocess

### DIFF
--- a/src/Services/Storage/Implementation/InstanceRepository.cs
+++ b/src/Services/Storage/Implementation/InstanceRepository.cs
@@ -77,7 +77,7 @@ namespace LocalTest.Services.Storage.Implementation
             return null;
         }
 
-        public Task<InstanceQueryResponse> GetInstancesFromQuery(Dictionary<string, StringValues> queryParams, string continuationToken, int size)
+        public async Task<InstanceQueryResponse> GetInstancesFromQuery(Dictionary<string, StringValues> queryParams, string continuationToken, int size)
         {
             List<string> validQueryParams = new List<string>
             {
@@ -202,13 +202,13 @@ namespace LocalTest.Services.Storage.Implementation
 
             instances.RemoveAll(i => i.Status.IsHardDeleted == true);
 
-            instances.ForEach(async i => await PostProcess(i));
+            await Task.WhenAll(instances.Select(async i => await PostProcess(i)));
 
-            return Task.FromResult(new InstanceQueryResponse
+            return new InstanceQueryResponse
             {
                 Instances = instances,
                 Count = instances.Count,
-            });
+            };
         }
 
         public async Task<Instance> Update(Instance instance)

--- a/src/Services/Storage/Implementation/InstanceRepository.cs
+++ b/src/Services/Storage/Implementation/InstanceRepository.cs
@@ -199,6 +199,10 @@ namespace LocalTest.Services.Storage.Implementation
             {
                 RemoveForDateTime(instances, $"{nameof(Instance.Process)}.{nameof(Instance.Process.Ended)}", queryParams.GetValueOrDefault("process.ended"));
             }
+            if (queryParams.ContainsKey("process.currentTask"))
+            {
+                instances.RemoveAll(i => !queryParams["process.currentTask"].Contains(i.Process.CurrentTask.ElementId));
+            }
 
             instances.RemoveAll(i => i.Status.IsHardDeleted == true);
 


### PR DESCRIPTION
Make InstanceRepository.GetInstancesFromQuery async and await postProcess function call.

When getting a list of instances of an app, there is an async call to PostProcess, that fills in data-array (among other tings). The GetInstances method did not await this postProcess.

## Description
The whole function is made async. The ForEach call is replaced with Select, and wrapped in Task.WhenAll(  ).
The Task wrapper on the returned object is removed.

## Related Issue(s)
None. Issue was discussed on Slack channel produkt-altinn-studio

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
