### PR TITLE
Fix NullPointerException with completed instances in GetInstancesByQuery.

### DIFF
--- a/src/Services/Storage/Implementation/InstanceRepository.cs
+++ b/src/Services/Storage/Implementation/InstanceRepository.cs
@@ -201,7 +201,7 @@ namespace LocalTest.Services.Storage.Implementation
             }
             if (queryParams.ContainsKey("process.currentTask"))
             {
-                instances.RemoveAll(i => !queryParams["process.currentTask"].Contains(i.Process.CurrentTask.ElementId));
+                instances.RemoveAll(i => !queryParams["process.currentTask"].Contains(i.Process.CurrentTask?.ElementId));
             }
 
             instances.RemoveAll(i => i.Status.IsHardDeleted == true);


### PR DESCRIPTION
[My previous PR](https://github.com/Altinn/app-localtest/pull/110) introduced a NullPointerException for completed instances, which caused GetInstancesByQuery to only return 500 Server error when there are complete instances in the storage. This PR fixes this issue.

## Description
Added [null conditional](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/member-access-operators#null-conditional-operators--and-) to the problematic object.

## Related Issue(s)
None

## Verification
- [X] **Your** code builds clean without any errors or warnings
- [X] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
