### PR TITLE
Treat `FlowType=AbandonCurrentMoveToNext` as `reject` action

### DIFF
--- a/src/Controllers/Storage/ProcessController.cs
+++ b/src/Controllers/Storage/ProcessController.cs
@@ -61,50 +61,45 @@ namespace Altinn.Platform.Storage.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         [Produces("application/json")]
         public async Task<ActionResult<Instance>> PutProcess(
-                int instanceOwnerPartyId,
-                Guid instanceGuid,
-                [FromBody] ProcessState processState)
+            int instanceOwnerPartyId,
+            Guid instanceGuid,
+            [FromBody] ProcessState processState
+        )
         {
-            Instance existingInstance;
+            Instance existingInstance = await _instanceRepository.GetOne(
+                instanceOwnerPartyId,
+                instanceGuid
+            );
 
-            existingInstance = await _instanceRepository.GetOne(instanceOwnerPartyId, instanceGuid);
-
-            if (existingInstance == null)
+            if (existingInstance is null)
             {
                 return NotFound();
             }
 
-            string altinnTaskType = existingInstance.Process?.CurrentTask?.AltinnTaskType;
             string taskId = null;
-            
-            var moveNextFlows = new []{"CompleteCurrentMoveToNext", "AbandonCurrentMoveToNext"};
-            if (processState?.CurrentTask?.FlowType is not null && !moveNextFlows.Contains(processState.CurrentTask.FlowType))
+            string altinnTaskType = existingInstance.Process?.CurrentTask?.AltinnTaskType;
+
+            if (processState?.CurrentTask?.FlowType == "AbandonCurrentMoveToNext")
+            {
+                altinnTaskType = "data";
+            }
+            else if (
+                processState?.CurrentTask?.FlowType is not null
+                && processState.CurrentTask.FlowType != "CompleteCurrentMoveToNext"
+            )
             {
                 altinnTaskType = processState.CurrentTask.AltinnTaskType;
                 taskId = processState.CurrentTask.ElementId;
             }
 
-            string action;
-
-            switch (altinnTaskType)
+            string action = altinnTaskType switch
             {
-                case "data":
-                case "feedback":
-                    action = "write";
-                    break;
-                case "payment":
-                    action = "pay";
-                    break;
-                case "confirmation":
-                    action = "confirm";
-                    break;
-                case "signing":
-                    action = "sign";
-                    break;
-                default:
-                    action = altinnTaskType;
-                    break;
-            }
+                "data" or "feedback" => "write",
+                "payment" => "pay",
+                "confirmation" => "confirm",
+                "signing" => "sign",
+                _ => altinnTaskType,
+            };
 
             bool authorized = await _authorizationService.AuthorizeInstanceAction(existingInstance, action, taskId);
 

--- a/src/Controllers/Storage/ProcessController.cs
+++ b/src/Controllers/Storage/ProcessController.cs
@@ -81,7 +81,7 @@ namespace Altinn.Platform.Storage.Controllers
 
             if (processState?.CurrentTask?.FlowType == "AbandonCurrentMoveToNext")
             {
-                altinnTaskType = "data";
+                altinnTaskType = "reject";
             }
             else if (
                 processState?.CurrentTask?.FlowType is not null

--- a/src/Controllers/Storage/ProcessController.cs
+++ b/src/Controllers/Storage/ProcessController.cs
@@ -109,7 +109,7 @@ namespace Altinn.Platform.Storage.Controllers
             }
 
             // Archiving instance if process was ended
-            if (existingInstance.Process.Ended == null && processState?.Ended != null)
+            if (existingInstance.Process?.Ended is null && processState?.Ended is not null)
             {
                 existingInstance.Status ??= new InstanceStatus();
                 existingInstance.Status.IsArchived = true;


### PR DESCRIPTION
## Description
Due to a patch in https://github.com/Altinn/altinn-storage/pull/414, ProcessController treats `FlowType=AbandonCurrentMoveToNext` identically to `FlowType=CompleteCurrentMoveToNext`. This has now proven to be problematic, as described in https://github.com/Altinn/app-lib-dotnet/issues/818.

This PR intercepts `AbandonCurrentMoveToNext` and treats it as `reject` instead of whatever `altinn:taskType` from the current step was.

**NOTE**: This functionality must be implemented in [altinn-storage](https://github.com/Altinn/altinn-storage) as well. This will be the next step, after we have confirmed functionality and reached agreement on how it should look in localtest.

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/issues/818

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
