### PR TITLE
Fix inconsistency in sub-units for DDG fitness

### DIFF
--- a/testdata/authorization/partylist/1337.json
+++ b/testdata/authorization/partylist/1337.json
@@ -27,7 +27,7 @@
         "partyTypeName": 2,
         "OrgNumber": "897069651",
         "unitType": "BEDR",
-        "name": "DDG Fitness Bergen",
+        "name": "DDG Fitness Oslo",
         "isDeleted": false,
         "onlyHierarchyElementWithNoAccess": false,
         "person": null,
@@ -39,7 +39,7 @@
         "partyTypeName": 2,
         "OrgNumber": "897069652",
         "unitType": "BEDR",
-        "name": "DDG Fitness Oslo",
+        "name": "DDG Fitness Bergen",
         "isDeleted": false,
         "onlyHierarchyElementWithNoAccess": false,
         "person": null,
@@ -58,7 +58,6 @@
         "organisation": null,
         "childParties": null
       }
-
     ]
   },
   {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

In the test-data for parties, Oslo and Bergen has the orgnr. `897069651` and `897069652` respectively, as can be seen here:

<img width="389" alt="image" src="https://github.com/user-attachments/assets/a0748f34-c156-4ea0-9578-63c30a09d7ce">

<img width="389" alt="image" src="https://github.com/user-attachments/assets/064c5f9c-bec7-4b77-91f8-020c401772dd">

But these were switched around in the partylist file for DDG fitness under `childParties`, resulting in an inconsistency depending on if we are checking the party in the currentParty response, or if we are matching the instance owner from the instance data with the list of parties:

<img width="864" alt="Screenshot 2024-10-11 at 11 15 10" src="https://github.com/user-attachments/assets/528f89ce-1227-4248-80b3-cc186a872764">


## Related Issue(s)
- Discovered while looking into https://github.com/Altinn/app-frontend-react/issues/2568

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
