### PR TITLE
Fix discovery document to not print `null` for bolean properties

### DIFF
--- a/src/Models/Authentication/DiscoveryDocument.cs
+++ b/src/Models/Authentication/DiscoveryDocument.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using System.Text.Json.Serialization;
 
 namespace Altinn.Platform.Authentication.Model
@@ -12,120 +13,135 @@ namespace Altinn.Platform.Authentication.Model
         /// URL of the issuer
         /// </summary>
         [JsonPropertyName("issuer")]
-        public string Issuer { get; set; }
+        public required string Issuer { get; set; }
 
         /// <summary>
         /// URL of the JSON Web Key Set document.
         /// </summary>
         [JsonPropertyName("jwks_uri")]
-        public string JwksUri { get; set; }
+        public required string JwksUri { get; set; }
 
         /// <summary>
         /// URL of the OAuth 2.0 Authorization Endpoint.
         /// </summary>
         [JsonPropertyName("authorization_endpoint")]
-        public string AuthorizationEndpoint { get; set; }
+        public required string AuthorizationEndpoint { get; set; }
 
         /// <summary>
         /// URL of the OAuth 2.0 Token Endpoint.
         /// </summary>
         [JsonPropertyName("token_endpoint")]
-        public string TokenEndpoint { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? TokenEndpoint { get; set; }
 
         /// <summary>
         /// Url of the UserInfo Endpoint.
         /// </summary>
         [JsonPropertyName("userinfo_endpoint")]
-        public string UserinfoEndpoint { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? UserinfoEndpoint { get; set; }
 
         /// <summary>
         /// URL of the end session Endpoint.
         /// </summary>
         [JsonPropertyName("end_session_endpoint")]
-        public string EndSessionEndpoint { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? EndSessionEndpoint { get; set; }
 
         /// <summary>
         /// URL for the session check Endpoint.
         /// </summary>
         [JsonPropertyName("check_session_iframe")]
-        public string CheckSessionIframe { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? CheckSessionIframe { get; set; }
 
         /// <summary>
         /// URL for the revocation endpoint.
         /// </summary>
         [JsonPropertyName("revocation_endpoint")]
-        public string RevocationEndpoint { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? RevocationEndpoint { get; set; }
 
         /// <summary>
         /// URL for the introspection endpoint.
         /// </summary>
         [JsonPropertyName("introspection_endpoint")]
-        public string IntrospectionEndpoint { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string? IntrospectionEndpoint { get; set; }
 
         /// <summary>
         /// Value indicating whether there is a front channel mechanism for logout.
         /// </summary>
         [JsonPropertyName("frontchannel_logout_supported")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? FrontchannelLogoutSupported { get; set; }
 
         /// <summary>
         /// Value indicating wheter there is a front channel mechanism for session logout.
         /// </summary>
         [JsonPropertyName("frontchannel_logout_session_supported")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public bool? FrontchannelLogoutSessionSupported { get; set; }
 
         /// <summary>
         /// Array of supported scopes.
         /// </summary>
         [JsonPropertyName("scopes_supported")]
-        public string[] ScopesSupported { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string[]? ScopesSupported { get; set; }
 
         /// <summary>
         /// Array of supported claims.
         /// </summary>
         [JsonPropertyName("claims_supported")]
-        public string[] ClaimsSupported { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string[]? ClaimsSupported { get; set; }
 
         /// <summary>
         /// Array of supported response types.
         /// </summary>
         [JsonPropertyName("response_types_supported")]
-        public string[] ResponseTypesSupported { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string[]? ResponseTypesSupported { get; set; }
 
         /// <summary>
         /// Array of supported response modes.
         /// </summary>
         [JsonPropertyName("response_modes_supported")]
-        public string[] ResponseModesSupported { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public  string[]? ResponseModesSupported { get; set; }
 
         /// <summary>
         /// Array of supported grant types.
         /// </summary>
         [JsonPropertyName("grant_types_supported")]
-        public string[] GrantTypesSupported { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string[]? GrantTypesSupported { get; set; }
 
         /// <summary>
         /// Array of supported subject types.
         /// </summary>
         [JsonPropertyName("subject_types_supported")]
-        public string[] SubjectTypesSupported { get; set; }
+        public required string[] SubjectTypesSupported { get; set; }
 
         /// <summary>
         /// Array of supported signing algorithms.
         /// </summary>
         [JsonPropertyName("id_token_signing_alg_values_supported")]
-        public string[] IdTokenSigningAlgValuesSupported { get; set; }
+        public required string[] IdTokenSigningAlgValuesSupported { get; set; }
 
         /// <summary>
         /// Array of supported authentication methods on the token endpoint.
         /// </summary>
         [JsonPropertyName("token_endpoint_auth_methods_supported")]
-        public string[] TokenEndpointAuthMethodsSupported { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string[]? TokenEndpointAuthMethodsSupported { get; set; }
 
         /// <summary>
         /// Array of supported code challenge methods.
         /// </summary>
         [JsonPropertyName("code_challenge_methods_supported")]
-        public string[] CodeChallengeMethodsSupported { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string[]? CodeChallengeMethodsSupported { get; set; }
     }
 }


### PR DESCRIPTION
This crashes on the latest version of
Microsoft.IdentityModel.Protocols.OpenIdConnect
And is required for app-lib-dotnet 8.5

## Related Issue(s)
Must be merged before
- https://github.com/Altinn/app-lib-dotnet/pull/920/files

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
