### PR TITLE
New page for easily finding the Urls for localtest ApiTokens

### DIFF
--- a/src/Configuration/LocalPlatformSettings.cs
+++ b/src/Configuration/LocalPlatformSettings.cs
@@ -41,7 +41,7 @@ namespace LocalTest.Configuration
             }
         }
 
-        public string LocalFrontendHostname { get; set; }
+        public string LocalFrontendHostname { get; set; } = "localhost";
         
         public string LocalFrontendProtocol { get; set; } = "http";
         

--- a/src/Models/TokensModel.cs
+++ b/src/Models/TokensModel.cs
@@ -1,0 +1,11 @@
+#nullable enable
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace LocalTest.Models;
+
+public class TokensViewModel
+{
+    public required IEnumerable<SelectListItem> TestUsers { get; init; }
+    public required List<SelectListItem> AuthenticationLevels { get; init; }
+    public required string DefaultOrg { get; init; }
+}

--- a/src/Services/Authentication/Interface/IAuthentication.cs
+++ b/src/Services/Authentication/Interface/IAuthentication.cs
@@ -19,8 +19,15 @@ namespace LocalTest.Services.Authentication.Interface
         /// </summary>
         /// <param name="org">Three letter application owner name (eg, TST )</param>
         /// <param name="orgNumber">Optional Organization number for the application owner. Will be fetched if not provided</param>
+        /// <param name="scopes">Space separated scopes for the token. If null default to "altinn:serviceowner/instances.read"</param>
+        /// <param name="authenticationLevel">The authentication level of the generated token</param>
         /// <returns>JWT token</returns>
-        public Task<string> GenerateTokenForOrg(string org, string? orgNumber = null, string? scopes = null);
+        public Task<string> GenerateTokenForOrg(
+            string org,
+            string? orgNumber = null,
+            string? scopes = null,
+            int? authenticationLevel = null
+        );
 
         /// <summary>
         /// Get JWT token for user profile

--- a/src/Views/Home/Tokens.cshtml
+++ b/src/Views/Home/Tokens.cshtml
@@ -1,0 +1,71 @@
+@model TokensViewModel
+@{
+  ViewData["Title"] = "Tokens for localtest";
+}
+<div class="container">
+    <h1 class="display-4">Welcome to Altinn App Local Testing</h1>
+    <p>Create tokens for accessing the localtest apis.</p>
+
+    <div class="alert alert-warning">Note that LocalTest is not an exact replica of the production systems, and that there are differences</div>
+
+    <div class="flex flex-column">
+
+        <h2>Generate end users token (like from idporten)</h2>
+        @using (Html.BeginForm("GetTestUserToken", "Home", FormMethod.Get, new { Class = "form" }))
+        {
+            <div class="form-group">
+                <label>Select user</label>
+                @Html.DropDownList("userId", Model.TestUsers, new { Class = "form-control" })
+            </div>
+            <div class="form-group">
+                <label>Select your authentication level</label>
+                @Html.DropDownList("authenticationLevel", Model.AuthenticationLevels, new { Class = "form-control" })
+            </div>
+
+            <div class="form-group">
+                <button type="submit" class="btn btn-primary">Get User token</button>
+            </div>
+        }
+        </div>
+        <div class="flex flex-column">
+        <h2>Service owner tokens</h2>
+        @using (Html.BeginForm("GetTestOrgToken", "Home", FormMethod.Get, new { Class = "form-signin" }))
+        {
+            <div class="form-group">
+                <label>Select service owner org</label>
+                @Html.TextBox("org", Model.DefaultOrg, new { Class = "form-control" })
+            </div>
+            <div class="form-group">
+                <label>Select your authentication level</label>
+                @Html.DropDownList("authenticationLevel", Model.AuthenticationLevels, new { Class = "form-control" })
+            </div>
+            <div class="form-group">
+                <label>optional org number for the token</label>
+                @Html.TextBox("orgNumber", "", new { Class = "form-control", Placeholder = "For official orgs this is fetch from altinncdn.no" })
+            </div>
+            <div class="form-group">
+                <label>Scopes for the token separated by space " " (scopes does not seem to be verified by localtest storage)</label>
+
+                @Html.TextBox("scopes", "", new { Class = "form-control", Id = "scopes", PlaceHolder = "altinn:serviceowner/instances.read" })
+            </div>
+
+            <div class="form-group">
+                <button type="submit" class="btn btn-primary">Get Org token</button>
+            </div>
+        }
+    </div>
+</div>
+
+@section Scripts
+{
+    <script>
+        document.getElementByid("addScopeBtn")
+    </script>
+}
+
+@section Styles
+{
+    <style>
+
+    </style>
+}

--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -6,6 +6,7 @@
     <title>@ViewData["Title"] - Altinn Studio</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <link rel="stylesheet" href="~/localtestresources/css/site.css" />
+    @RenderSection("Styles", required: false)
 </head>
 <body>
     <header>
@@ -28,6 +29,10 @@
                         <li class="nav-item">
                             <a class="nav-link text-secondary" asp-area="" asp-controller="TenorUsers"
                                 asp-action="Index">User administration</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Home"
+                                asp-action="Tokens">Tokens</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="StorageExplorer" asp-action="Index">Storage Explorer</a>


### PR DESCRIPTION
I'm tired of answering the question on how to get API tokens in localtest, so now they are available on a separate page.

I did my best to mimic the current design as much as possible.

<img width="1167" alt="image" src="https://github.com/user-attachments/assets/ef776650-d717-469d-a5bb-a69f4ac1cb60">
