### PR TITLE
Make Localtest compile without warnings

### DIFF
--- a/src/Notifications/.editorconfig
+++ b/src/Notifications/.editorconfig
@@ -1,0 +1,9 @@
+[API/**/*.cs]
+# Ignore CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+# because the API project uses nullable reference types, but is copied to a context where we don't use them.
+dotnet_diagnostic.CS8632.severity = none
+
+[Core/**/*.cs]
+# Ignore CS8632: The annotation for nullable reference types should only be used in code within a '#nullable' annotations context.
+# because the Core project uses nullable reference types, but is copied to a context where we don't use them.
+dotnet_diagnostic.CS8632.severity = none

--- a/src/Services/Register/Implementation/TooManyFailedLookupsException.cs
+++ b/src/Services/Register/Implementation/TooManyFailedLookupsException.cs
@@ -1,12 +1,8 @@
-using System;
-using System.Runtime.Serialization;
-
 namespace Altinn.Platform.Register.Core
 {
     /// <summary>
     /// Represents a situation where a user has performed too many failed lookup requests.
     /// </summary>
-    [Serializable]
     public class TooManyFailedLookupsException : Exception
     {
         /// <summary>
@@ -22,15 +18,6 @@ namespace Altinn.Platform.Register.Core
         /// <param name="message">The message that descibes the error.</param>
         public TooManyFailedLookupsException(string message)
             : base(message)
-        {
-        }
-
-        /// <summary>
-        /// Initialize a new instance of the <see cref="TooManyFailedLookupsException"/> class using the
-        /// given <see cref="SerializationInfo"/>.
-        /// </summary>
-        protected TooManyFailedLookupsException(SerializationInfo info, StreamingContext context)
-            : base(info, context)
         {
         }
     }


### PR DESCRIPTION
* Remove obsolete seralization for exception
* Ignore CS8632 for copied code in notifications, because we don't want to modify copied files to have `#nullable enable`.
