### PR TITLE
Enable passing scopes to org token

### DIFF
--- a/src/Controllers/HomeController.cs
+++ b/src/Controllers/HomeController.cs
@@ -201,10 +201,10 @@ namespace LocalTest.Controllers
         /// <param name="id"></param>
         /// <returns></returns>
         [HttpGet("{id}")]
-        public async Task<ActionResult> GetTestOrgToken(string id, [FromQuery] string orgNumber = null)
+        public async Task<ActionResult> GetTestOrgToken(string id, [FromQuery] string orgNumber = null, [FromQuery] string scopes = null)
         {
             // Create a test token with long duration
-            string token = await _authenticationService.GenerateTokenForOrg(id, orgNumber);
+            string token = await _authenticationService.GenerateTokenForOrg(id, orgNumber, scopes);
 
             return Ok(token);
         }

--- a/src/Services/Authentication/Implementation/AuthenticationService.cs
+++ b/src/Services/Authentication/Implementation/AuthenticationService.cs
@@ -56,7 +56,7 @@ public class AuthenticationService : IAuthentication
     }
 
     /// <inheritdoc />
-    public async Task<string> GenerateTokenForOrg(string org, string? orgNumber = null)
+    public async Task<string> GenerateTokenForOrg(string org, string? orgNumber = null, string? scopes = null)
     {
         if (orgNumber is null)
         {
@@ -69,7 +69,8 @@ public class AuthenticationService : IAuthentication
         claims.Add(new Claim(AltinnCoreClaimTypes.Org, org.ToLower(), ClaimValueTypes.String, issuer));
         // 3 is the default level for altinn tokens form Maskinporten
         claims.Add(new Claim(AltinnCoreClaimTypes.AuthenticationLevel, "3", ClaimValueTypes.Integer32, issuer));
-        claims.Add(new Claim("urn:altinn:scope", "altinn:serviceowner/instances.read", ClaimValueTypes.String, issuer));
+        scopes ??= "altinn:serviceowner/instances.read";
+        claims.Add(new Claim("urn:altinn:scope", scopes, ClaimValueTypes.String, issuer));
         if (!string.IsNullOrEmpty(orgNumber))
         {
             claims.Add(new Claim(AltinnCoreClaimTypes.OrgNumber, orgNumber, ClaimValueTypes.String, issuer));

--- a/src/Services/Authentication/Interface/IAuthentication.cs
+++ b/src/Services/Authentication/Interface/IAuthentication.cs
@@ -20,7 +20,7 @@ namespace LocalTest.Services.Authentication.Interface
         /// <param name="org">Three letter application owner name (eg, TST )</param>
         /// <param name="orgNumber">Optional Organization number for the application owner. Will be fetched if not provided</param>
         /// <returns>JWT token</returns>
-        public Task<string> GenerateTokenForOrg(string org, string? orgNumber = null);
+        public Task<string> GenerateTokenForOrg(string org, string? orgNumber = null, string? scopes = null);
 
         /// <summary>
         /// Get JWT token for user profile


### PR DESCRIPTION
## Description
Scopes typically come from the caller, so this enables users to inject their own scopes

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
