### PR TITLE
Chore/ add org test data with valid org nr

### DIFF
--- a/testdata/Register/Org/043871668.json
+++ b/testdata/Register/Org/043871668.json
@@ -1,0 +1,16 @@
+{
+    "OrgNumber": "043871668",
+    "Name": "Skog og Fjell Consulting",
+    "UnitType": "AS",
+    "TelephoneNumber": "12345678",
+    "MobileNumber": "92011000",
+    "FaxNumber": "92110100",
+    "EMailAddress": "epost@fjellet.no",
+    "InternetAddress": "http://fjellbrl.no",
+    "MailingAddress": "Sofies Gate 21",
+    "MailingPostalCode": "0170",
+    "MailingPostalCity": "Oslo",
+    "BusinessAddress": "Sofies Gate 21",
+    "BusinessPostalCode": "0170",
+    "BusinessPostalCity": "By"
+}

--- a/testdata/Register/Party/500004.json
+++ b/testdata/Register/Party/500004.json
@@ -1,0 +1,13 @@
+{
+    "partyId": "500004",
+    "partyTypeName": 2,
+    "orgNumber": "043871668",
+    "ssn": null,
+    "unitType": "BEDR",
+    "name": "Skog og Fjell Consulting",
+    "isDeleted": false,
+    "onlyHierarchyElementWithNoAccess": false,
+    "person": null,
+    "organisation": null,
+    "childParties": null
+}


### PR DESCRIPTION
For testing the organisation lookup component locally. We do the [mod11 check ](https://www.brreg.no/om-oss/registrene-vare/om-enhetsregisteret/organisasjonsnummeret/) for org numbers to validate. The test data for organisations which already exist in localtest do not pass this test.