### PR TITLE
Add TTD org in register test data

### DIFF
--- a/testdata/Register/Org/405003309.json
+++ b/testdata/Register/Org/405003309.json
@@ -1,0 +1,16 @@
+{
+  "OrgNumber": "405003309",
+  "Name": "Testdepartementet",
+  "UnitType": "AS",
+  "TelephoneNumber": "12345678",
+  "MobileNumber": "92010000",
+  "FaxNumber": "92110000",
+  "EMailAddress": "localtest@digdir.no",
+  "InternetAddress": "http://digdir.no",
+  "MailingAddress": "Lørenfaret 1C",
+  "MailingPostalCode": "0580",
+  "MailingPostalCity": "Oslo",
+  "BusinessAddress": "Lørenfaret 1C",
+  "BusinessPostalCode": "0580",
+  "BusinessPostalCity": "Oslo"
+}

--- a/testdata/Register/Party/500005.json
+++ b/testdata/Register/Party/500005.json
@@ -1,0 +1,13 @@
+{
+    "partyId": "500005",
+    "partyTypeName": 2,
+    "orgNumber": "405003309",
+    "ssn": null,
+    "unitType": "BEDR",
+    "name": "Testdepartementet",
+    "isDeleted": false,
+    "onlyHierarchyElementWithNoAccess": false,
+    "person": null,
+    "organisation": null,
+    "childParties": null
+}


### PR DESCRIPTION
## Description
Noting this down for now.... For some auth scenarios I've been testing and verifying it's been helpful to be able to lookup ttd from register. Then we can test out org tokens, service owner tokens etc... I think ttd is the only service owner that doesn't have an org nr.

In the case of process/next with a service owner token (ttd being the service owner), with https://github.com/Altinn/app-frontend-react/pull/2889 and https://github.com/Altinn/app-lib-dotnet/pull/880 we can instantiate and process/next with org token for ttd with this change

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
