### PR TITLE
docs: update configuration guide for port changes affecting PDF gener…

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,15 @@ Sometimes the local environment have another service running on port 80, so you 
 ALTINN3LOCAL_PORT=80
 ```
 
+> [!NOTE]
+> If you change the port, you must also update the `HostName` in `appsettings.json` in your form application for PDF generation to work correctly. For example:
+> 
+> ```json
+>"GeneralSettings": {
+>  "HostName": "local.altinn.cloud:<PORTNUMBER>",  
+> }
+> ```
+
 If you want to see the storage files on disk (instead of reading them through the browser), change this to a local
 path on your computer (ensure that it exists)
 


### PR DESCRIPTION
## Description
Add note explaining that when changing the default port in Docker Compose setup, the HostName in appsettings.json must also be updated to include the new port number for PDF generation to work correctly.

This clarifies the connection between changing the Docker port configuration and updating the app's HostName setting to ensure PDF generation functions properly.

## Related Issue(s)
- No specific issue ticket, but addresses an aspect of local development setup

## Verification
- [x] Documentation-only change

## Documentation
- [x] This PR is a documentation update itself