### PR TITLE
Log potential errors in Authorization decision endpoint

### DIFF
--- a/src/Controllers/Authorization/DecisionController.cs
+++ b/src/Controllers/Authorization/DecisionController.cs
@@ -72,8 +72,10 @@ namespace Altinn.Platform.Authorization.Controllers
                     return await AuthorizeXmlRequest(model); // lgtm [cs/user-controlled-bypass]
                 }
             }
-            catch
+            catch (Exception ex)
             {
+                _logger.LogError(ex, "Error occured in DecisionController");
+
                 XacmlContextResult result = new XacmlContextResult(XacmlContextDecision.Indeterminate)
                 {
                     Status = new XacmlContextStatus(XacmlContextStatusCode.SyntaxError)


### PR DESCRIPTION
## Description
I think it's better to log the error then to ignore any exception and return `syntax-error` when executing authorization requests

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
