### PR TITLE
Null-check party when trying to enrich subject attributes during authz

### DIFF
--- a/src/Services/Authorization/Implementation/ContextHandler.cs
+++ b/src/Services/Authorization/Implementation/ContextHandler.cs
@@ -343,7 +343,10 @@ namespace Altinn.Platform.Authorization.Services.Implementation
             if (!string.IsNullOrEmpty(subjectOrgnNo))
             {
                 Party party = await _partiesWrapper.LookupPartyBySSNOrOrgNo(subjectOrgnNo);
-                subjectContextAttributes.Attributes.Add(GetPartyIdsAttribute(new List<int> { party.PartyId }));
+                if (party is not null)
+                {
+                    subjectContextAttributes.Attributes.Add(GetPartyIdsAttribute(new List<int> { party.PartyId }));
+                }
             }
 
             // No need for further enrichment of roles of no user subject exists


### PR DESCRIPTION
## Description
Found this when doing service owner requests with an orgNo that had no party information in localtest (digdirs orgno, pretending to be ttd)

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
