### PR TITLE
fix to make form load with xml file

### DIFF
--- a/src/Controllers/HomeController.cs
+++ b/src/Controllers/HomeController.cs
@@ -166,7 +166,7 @@ namespace LocalTest.Controllers
                         },
                     };
 
-                    var xmlDataId = app.DataTypes.First(dt => dt.AppLogic is not null).Id;
+                    var xmlDataId = app.DataTypes.First(dt => dt.AppLogic?.ClassRef is not null).Id;
 
                     using var reader = new StreamReader(prefill.OpenReadStream());
                     var content = await reader.ReadToEndAsync();


### PR DESCRIPTION
When you attempt to load the form with the XML-file containing the form data you get the following error: 

An unhandled exception occurred while processing the request.
HttpRequestException: "Error when comparing content to application metadata: The multipart section named ref-data-as-pdf has a Content-Type 'application/xml; charset=utf-8' which is invalid for element type 'ref-data-as-pdf'"
LocalTest.Services.LocalApp.Implementation.LocalAppHttp.Instantiate(string appId, Instance instance, string xmlPrefill, string xmlDataId, string token) in LocalAppHttp.cs, line 118


This PR implements the change suggested by "ivarne".



