### PR TITLE
Fix bug by adding apps by app Id instead of directory name

### DIFF
--- a/src/Services/LocalApp/Implementation/LocalAppFile.cs
+++ b/src/Services/LocalApp/Implementation/LocalAppFile.cs
@@ -84,7 +84,7 @@ namespace LocalTest.Services.LocalApp.Implementation
                 Application? app = await GetApplicationMetadata(directory);
                 if (app != null)
                 {
-                    ret.Add(directory, app);
+                    ret.Add(app.Id, app);
                 }
             }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix a bug where apps using file mode could not be found by application metadata when fetching applications. 

## Related Issue(s)
- #{issue number}

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [x] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
