### PR TITLE
Add TTD org in register test data

### DIFF
--- a/testdata/Register/Org/405003309.json
+++ b/testdata/Register/Org/405003309.json
@@ -1,0 +1,16 @@
+{
+  "OrgNumber": "405003309",
+  "Name": "Testdepartementet",
+  "UnitType": "AS",
+  "TelephoneNumber": "12345678",
+  "MobileNumber": "92010000",
+  "FaxNumber": "92110000",
+  "EMailAddress": "localtest@digdir.no",
+  "InternetAddress": "http://digdir.no",
+  "MailingAddress": "Lørenfaret 1C",
+  "MailingPostalCode": "0580",
+  "MailingPostalCity": "Oslo",
+  "BusinessAddress": "Lørenfaret 1C",
+  "BusinessPostalCode": "0580",
+  "BusinessPostalCity": "Oslo"
+}

--- a/testdata/Register/Party/500005.json
+++ b/testdata/Register/Party/500005.json
@@ -1,0 +1,13 @@
+{
+    "partyId": "500005",
+    "partyTypeName": 2,
+    "orgNumber": "405003309",
+    "ssn": null,
+    "unitType": "BEDR",
+    "name": "Testdepartementet",
+    "isDeleted": false,
+    "onlyHierarchyElementWithNoAccess": false,
+    "person": null,
+    "organisation": null,
+    "childParties": null
+}


### PR DESCRIPTION
## Description
Reviving old PR: https://github.com/Altinn/app-localtest/pull/133

Because in order to have integration tests that use service owner tokens locally with the current setup we need ttd to have a party.
I think the alternative is if we don't use ttd as org for the apps we make for integration tests, but that seems like a hassle

The org nr used is the one apparantly registered in prod 

Old slack thread for some context: https://digdir.slack.com/archives/C079ZFUSFMW/p1733995244241709

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
