### PR TITLE
New test authentication methods

### DIFF
--- a/src/Controllers/TestAuthenticationController.cs
+++ b/src/Controllers/TestAuthenticationController.cs
@@ -1,0 +1,246 @@
+#nullable enable
+using Microsoft.AspNetCore.Mvc;
+using LocalTest.Models.Authentication;
+using LocalTest.Services.Authentication.Implementation;
+
+namespace LocalTest.Controllers;
+
+[Route("Home/auth")]
+[ApiController]
+public class TestAuthenticationController : ControllerBase
+{
+    private readonly ILogger<TestAuthenticationController> _logger;
+    private readonly TestAuthenticationService _testAuthenticationService;
+
+    public TestAuthenticationController(ILogger<TestAuthenticationController> logger, TestAuthenticationService testAuthenticationService)
+    {
+        _logger = logger;
+        _testAuthenticationService = testAuthenticationService;
+    }
+
+    /// <summary>
+    /// Generate a token for a regular user (Person with BankID authentication)
+    /// </summary>
+    /// <param name="userId">User ID (if not provided, uses first user from test data)</param>
+    /// <param name="partyId">Party ID (if not provided, uses first user from test data)</param>
+    /// <param name="authenticationLevel">Authentication level (default: 2)</param>
+    /// <param name="scope">Token scope (default: altinn:portal/enduser)</param>
+    /// <returns>JWT token</returns>
+    [HttpGet("user")]
+    public async Task<ActionResult> GetUserToken(
+        [FromQuery] int? userId = null,
+        [FromQuery] int? partyId = null,
+        [FromQuery] int authenticationLevel = 2,
+        [FromQuery] string? scope = null
+    )
+    {
+        try
+        {
+            string token = await _testAuthenticationService.GetUserToken(userId, partyId, authenticationLevel, scope);
+            return Ok(token);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to generate user token");
+            return Problem(
+                detail: ex.Message,
+                title: "Failed to generate user token",
+                statusCode: 400
+            );
+        }
+    }
+
+    /// <summary>
+    /// Generate a token for a self-identified user (login without SSN/D-number)
+    /// </summary>
+    /// <param name="username">Username (required) - must match a username in test data</param>
+    /// <param name="scope">Token scope (default: altinn:portal/enduser)</param>
+    /// <returns>JWT token</returns>
+    [HttpGet("selfidentifieduser")]
+    public async Task<ActionResult> GetSelfIdentifiedUserToken(
+        [FromQuery] string username,
+        [FromQuery] string? scope = null
+    )
+    {
+        try
+        {
+            string token = await _testAuthenticationService.GetSelfIdentifiedUserToken(username, scope);
+            return Ok(token);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to generate self-identified user token");
+            return Problem(
+                detail: ex.Message,
+                title: "Failed to generate self-identified user token",
+                statusCode: 400
+            );
+        }
+    }
+
+    /// <summary>
+    /// Generate a token for an organization (Maskinporten token without service owner scopes)
+    /// </summary>
+    /// <param name="orgNumber">Organization number (if not provided, uses first org from test data)</param>
+    /// <param name="scope">Space-separated scopes (default: "altinn:instances.read altinn:instances.write")</param>
+    /// <returns>JWT token</returns>
+    [HttpGet("org")]
+    public async Task<ActionResult> GetOrgToken(
+        [FromQuery] string? orgNumber = null,
+        [FromQuery] string? scope = null
+    )
+    {
+        try
+        {
+            string token = await _testAuthenticationService.GetOrgToken(orgNumber, scope ?? TestAuthenticationService.DefaultOrgScope);
+            return Ok(token);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to generate org token");
+            return Problem(
+                detail: ex.Message,
+                title: "Failed to generate org token",
+                statusCode: 400
+            );
+        }
+    }
+
+    /// <summary>
+    /// Generate a token for a service owner (Maskinporten token with service owner scopes)
+    /// </summary>
+    /// <param name="orgNumber">Organization number (if not provided, uses first org from test data)</param>
+    /// <param name="scope">Space-separated scopes (default: service owner read/write scopes)</param>
+    /// <param name="org">Three-letter org code (required)</param>
+    /// <returns>JWT token</returns>
+    [HttpGet("serviceowner")]
+    public async Task<ActionResult> GetServiceOwnerToken(
+        [FromQuery] string? orgNumber = null,
+        [FromQuery] string? scope = null,
+        [FromQuery] string? org = null
+    )
+    {
+        try
+        {
+            string token = await _testAuthenticationService.GetServiceOwnerToken(orgNumber, scope ?? TestAuthenticationService.DefaultServiceOwnerScope, org);
+            return Ok(token);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to generate service owner token");
+            return Problem(
+                detail: ex.Message,
+                title: "Failed to generate service owner token",
+                statusCode: 400
+            );
+        }
+    }
+
+    /// <summary>
+    /// Generate a token for a system user (Maskinporten token with system user authorization details)
+    /// </summary>
+    /// <param name="systemId">System ID (required) - must exist in test data</param>
+    /// <param name="systemUserId">System User ID (required) - must exist in test data and belong to the specified system</param>
+    /// <param name="scope">Space-separated scopes (default: "altinn:instances.read altinn:instances.write")</param>
+    /// <returns>JWT token</returns>
+    [HttpGet("systemuser")]
+    public async Task<ActionResult> GetSystemUserToken(
+        [FromQuery] string systemId,
+        [FromQuery] string systemUserId,
+        [FromQuery] string? scope = null
+    )
+    {
+        try
+        {
+            string token = await _testAuthenticationService.GetSystemUserToken(systemId, systemUserId, scope);
+            return Ok(token);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to generate system user token");
+            return Problem(
+                detail: ex.Message,
+                title: "Failed to generate system user token",
+                statusCode: 400
+            );
+        }
+    }
+
+    /// <summary>
+    /// Generate a token by authentication type with flexible parameters
+    /// </summary>
+    /// <param name="type">Authentication type (User=1, SelfIdentifiedUser=2, Org=3, SystemUser=4, ServiceOwner=5)</param>
+    /// <param name="userId">User ID</param>
+    /// <param name="partyId">Party ID</param>
+    /// <param name="authenticationLevel">Authentication level</param>
+    /// <param name="username">Username</param>
+    /// <param name="orgNumber">Organization number</param>
+    /// <param name="org">Organization code</param>
+    /// <param name="scope">Scopes</param>
+    /// <param name="systemId">System ID</param>
+    /// <param name="systemUserId">System User ID</param>
+    /// <returns>JWT token</returns>
+    [HttpGet("generate")]
+    public async Task<ActionResult> GenerateToken(
+        [FromQuery] AuthenticationTypes type,
+        [FromQuery] int? userId = null,
+        [FromQuery] int? partyId = null,
+        [FromQuery] int authenticationLevel = 2,
+        [FromQuery] string? username = null,
+        [FromQuery] string? orgNumber = null,
+        [FromQuery] string? org = null,
+        [FromQuery] string? scope = null,
+        [FromQuery] string? systemId = null,
+        [FromQuery] string? systemUserId = null
+    )
+    {
+        try
+        {
+            string token = await _testAuthenticationService.GenerateToken(
+                type,
+                userId,
+                partyId,
+                authenticationLevel,
+                username,
+                orgNumber,
+                org,
+                scope,
+                systemId,
+                systemUserId
+            );
+            return Ok(token);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to generate token");
+            return Problem(
+                detail: ex.Message,
+                title: "Failed to generate token",
+                statusCode: 400
+            );
+        }
+    }
+
+    /// <summary>
+    /// Get information about available authentication types and test data
+    /// </summary>
+    /// <returns>Information about authentication types and available test data</returns>
+    [HttpGet("info")]
+    public async Task<ActionResult> GetInfo()
+    {
+        try
+        {
+            var info = await _testAuthenticationService.GetInfo();
+            return Ok(info);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to get test data info");
+            return Problem(
+                detail: ex.Message,
+                title: "Failed to get test data info",
+                statusCode: 500
+            );
+        }
+    }
+}

--- a/src/Models/Authentication/AuthenticationTypes.cs
+++ b/src/Models/Authentication/AuthenticationTypes.cs
@@ -1,0 +1,10 @@
+namespace LocalTest.Models.Authentication;
+
+public enum AuthenticationTypes
+{
+    User = 1,
+    SelfIdentifiedUser = 2,
+    Org = 3,
+    SystemUser = 4,
+    ServiceOwner = 5,
+}

--- a/src/Services/Authentication/Implementation/TestAuthenticationService.cs
+++ b/src/Services/Authentication/Implementation/TestAuthenticationService.cs
@@ -88,7 +88,8 @@ public class TestAuthenticationService
             { AltinnCoreClaimTypes.AuthenticationLevel, authLevel.ToString() },
             { "jti", Guid.NewGuid().ToString() },
             { "scope", scope ?? DefaultUserScope },
-            { "iss", iss }
+            { "iss", iss },
+            { "islocaltest", "true" }
         };
 
         return payload;
@@ -140,7 +141,8 @@ public class TestAuthenticationService
             { AltinnCoreClaimTypes.AuthenticationLevel, "0" },
             { "jti", Guid.NewGuid().ToString() },
             { "scope", scope ?? DefaultUserScope },
-            { "iss", iss }
+            { "iss", iss },
+            { "islocaltest", "true" }
         };
 
         return payload;
@@ -169,7 +171,8 @@ public class TestAuthenticationService
             { AltinnCoreClaimTypes.OrgNumber, orgNumber },
             { AltinnCoreClaimTypes.AuthenticateMethod, "maskinporten" },
             { AltinnCoreClaimTypes.AuthenticationLevel, "3" },
-            { "jti", Guid.NewGuid().ToString() }
+            { "jti", Guid.NewGuid().ToString() },
+            { "islocaltest", "true" }
         };
 
         return payload;
@@ -228,7 +231,8 @@ public class TestAuthenticationService
             { AltinnCoreClaimTypes.OrgNumber, orgNumber },
             { AltinnCoreClaimTypes.AuthenticateMethod, "maskinporten" },
             { AltinnCoreClaimTypes.AuthenticationLevel, "3" },
-            { "jti", Guid.NewGuid().ToString() }
+            { "jti", Guid.NewGuid().ToString() },
+            { "islocaltest", "true" }
         };
 
         return payload;
@@ -295,6 +299,7 @@ public class TestAuthenticationService
             { AltinnCoreClaimTypes.OrgNumber, supplierOrgNumber },
             { AltinnCoreClaimTypes.AuthenticateMethod, "maskinporten" },
             { AltinnCoreClaimTypes.AuthenticationLevel, "3" },
+            { "islocaltest", "true" }
         };
 
         AuthorizationDetailsClaim authorizationDetails = new SystemUserAuthorizationDetailsClaim(

--- a/src/Services/Authentication/Implementation/TestAuthenticationService.cs
+++ b/src/Services/Authentication/Implementation/TestAuthenticationService.cs
@@ -1,0 +1,482 @@
+#nullable enable
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text.Json;
+using AltinnCore.Authentication.Constants;
+using LocalTest.Models.Authentication;
+using LocalTest.Services.Authentication.Interface;
+using LocalTest.Services.TestData;
+using Altinn.Platform.Register.Models;
+using Altinn.Platform.Profile.Enums;
+
+namespace LocalTest.Services.Authentication.Implementation;
+
+public class TestAuthenticationService
+{
+    private readonly IAuthentication _authenticationService;
+    private readonly TestDataService _testDataService;
+
+    public const string DefaultServiceOwnerScope =
+        "altinn:serviceowner/instances.read altinn:serviceowner/instances.write";
+    public const string DefaultOrgScope = "altinn:instances.read altinn:instances.write";
+    public const string DefaultUserScope = "altinn:portal/enduser";
+
+    public TestAuthenticationService(IAuthentication authenticationService, TestDataService testDataService)
+    {
+        _authenticationService = authenticationService;
+        _testDataService = testDataService;
+    }
+
+    public async Task<string> GenerateToken(
+        AuthenticationTypes type,
+        int? userId = null,
+        int? partyId = null,
+        int authenticationLevel = 2,
+        string? username = null,
+        string? orgNumber = null,
+        string? org = null,
+        string? scope = null,
+        string? systemId = null,
+        string? systemUserId = null
+    )
+    {
+        return type switch
+        {
+            AuthenticationTypes.User => await GetUserToken(userId, partyId, authenticationLevel),
+            AuthenticationTypes.SelfIdentifiedUser => await GetSelfIdentifiedUserToken(username ?? throw new InvalidOperationException("Username is required for SelfIdentifiedUser tokens"), scope),
+            AuthenticationTypes.Org => await GetOrgToken(orgNumber, scope ?? DefaultOrgScope),
+            AuthenticationTypes.ServiceOwner => await GetServiceOwnerToken(orgNumber, scope ?? DefaultServiceOwnerScope, org),
+            AuthenticationTypes.SystemUser => await GetSystemUserToken(
+                systemId ?? throw new InvalidOperationException("SystemId is required for SystemUser tokens"),
+                systemUserId ?? throw new InvalidOperationException("SystemUserId is required for SystemUser tokens"),
+                scope),
+            _ => throw new InvalidOperationException("Unsupported token type: " + type),
+        };
+    }
+
+    public async Task<string> GetUserToken(
+        int? userId = null,
+        int? partyId = null,
+        int authenticationLevel = 2,
+        string? scope = null
+    )
+    {
+        var testData = await _testDataService.GetTestData();
+        
+        // Validate and resolve userId and partyId
+        var (actualUserId, actualPartyId) = ValidateAndResolveUserIds(testData, userId, partyId);
+
+        var payload = GetUserPayload(actualUserId, actualPartyId, authenticationLevel, scope);
+        return _authenticationService.GenerateToken(payload);
+    }
+
+    public static JwtPayload GetUserPayload(
+        int userId,
+        int partyId,
+        int authLevel = 2,
+        string? scope = null
+    )
+    {
+        string iss = "https://platform.tt02.altinn.no/authentication/api/v1/openid/";
+
+        var payload = new JwtPayload
+        {
+            { ClaimTypes.NameIdentifier, $"user-{userId}-{partyId}" },
+            { AltinnCoreClaimTypes.UserId, userId.ToString() },
+            { AltinnCoreClaimTypes.PartyID, partyId.ToString() },
+            { AltinnCoreClaimTypes.AuthenticateMethod, "BankID" },
+            { AltinnCoreClaimTypes.AuthenticationLevel, authLevel.ToString() },
+            { "jti", Guid.NewGuid().ToString() },
+            { "scope", scope ?? DefaultUserScope },
+            { "iss", iss }
+        };
+
+        return payload;
+    }
+
+    public async Task<string> GetSelfIdentifiedUserToken(
+        string username,
+        string? scope = null
+    )
+    {
+        var testData = await _testDataService.GetTestData();
+        
+        // Find user by username
+        var user = testData.Profile.User.Values.FirstOrDefault(u => u.UserName == username);
+        if (user is null)
+        {
+            var availableUsernames = testData.Profile.User.Values
+                .Where(u => !string.IsNullOrEmpty(u.UserName))
+                .Select(u => u.UserName)
+                .ToList();
+            throw new InvalidOperationException($"User with username '{username}' not found in test data. Available usernames: {string.Join(", ", availableUsernames)}");
+        }
+
+        if (user.UserType is not UserType.SelfIdentified)
+        {
+            throw new InvalidOperationException($"User with username '{username}' is not a self-identified user.");
+        }
+
+        var payload = GetSelfIdentifiedUserPayload(username, user.UserId, user.PartyId, scope);
+        return _authenticationService.GenerateToken(payload);
+    }
+
+    public static JwtPayload GetSelfIdentifiedUserPayload(
+        string username,
+        int userId,
+        int partyId,
+        string? scope = null
+    )
+    {
+        string iss = "https://platform.tt02.altinn.no/authentication/api/v1/openid/";
+
+        var payload = new JwtPayload
+        {
+            { ClaimTypes.NameIdentifier, $"user-{userId}-{partyId}" },
+            { AltinnCoreClaimTypes.UserId, userId.ToString() },
+            { AltinnCoreClaimTypes.UserName, username },
+            { AltinnCoreClaimTypes.PartyID, partyId.ToString() },
+            { AltinnCoreClaimTypes.AuthenticateMethod, "Mock" },
+            { AltinnCoreClaimTypes.AuthenticationLevel, "0" },
+            { "jti", Guid.NewGuid().ToString() },
+            { "scope", scope ?? DefaultUserScope },
+            { "iss", iss }
+        };
+
+        return payload;
+    }
+
+    public static JwtPayload GetOrgPayload(string orgNumber, string scope)
+    {
+        string iss = "https://platform.tt02.altinn.no/authentication/api/v1/openid/";
+
+        var scopes = new HashSet<string>(scope.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+        if (scopes.Any(s => s.StartsWith("altinn:serviceowner/")))
+            throw new InvalidOperationException("Org token cannot have serviceowner scopes");
+
+        var consumer = new OrgClaim(
+            "iso6523-actorid-upis",
+            $"0192:{orgNumber}"
+        );
+
+        var payload = new JwtPayload
+        {
+            { "iss", iss },
+            { "scope", scope },
+            { "token_type", "Bearer" },
+            { "client_id", Guid.NewGuid().ToString() },
+            { "consumer", JsonSerializer.SerializeToElement(consumer) },
+            { AltinnCoreClaimTypes.OrgNumber, orgNumber },
+            { AltinnCoreClaimTypes.AuthenticateMethod, "maskinporten" },
+            { AltinnCoreClaimTypes.AuthenticationLevel, "3" },
+            { "jti", Guid.NewGuid().ToString() }
+        };
+
+        return payload;
+    }
+
+    public async Task<string> GetOrgToken(
+        string? orgNumber = null,
+        string scope = DefaultOrgScope
+    )
+    {
+        var testData = await _testDataService.GetTestData();
+        var actualOrgNumber = ValidateAndResolveOrgNumber(testData, orgNumber);
+        var payload = GetOrgPayload(actualOrgNumber, scope);
+        return _authenticationService.GenerateToken(payload);
+    }
+
+
+    public async Task<string> GetServiceOwnerToken(
+        string? orgNumber = null,
+        string scope = DefaultServiceOwnerScope,
+        string? org = null
+    )
+    {
+        var testData = await _testDataService.GetTestData();
+        var actualOrgNumber = ValidateAndResolveOrgNumber(testData, orgNumber);
+        var actualOrg = org ?? throw new InvalidOperationException("Org code must be provided for service owner tokens");
+        var payload = GetServiceOwnerPayload(actualOrgNumber, scope, actualOrg);
+        return _authenticationService.GenerateToken(payload);
+    }
+
+    public static JwtPayload GetServiceOwnerPayload(
+        string orgNumber,
+        string scope,
+        string org
+    )
+    {
+        const string iss = "https://platform.tt02.altinn.no/authentication/api/v1/openid/";
+
+        var scopes = new HashSet<string>(scope.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+        if (!scopes.Any(s => s.StartsWith("altinn:serviceowner/")))
+            throw new InvalidOperationException("Service owner token must have serviceowner scopes");
+
+        var consumer = new OrgClaim(
+            "iso6523-actorid-upis",
+            $"0192:{orgNumber}"
+        );
+
+        var payload = new JwtPayload
+        {
+            { "iss", iss },
+            { "scope", scope },
+            { "token_type", "Bearer" },
+            { "client_id", Guid.NewGuid().ToString() },
+            { "consumer", JsonSerializer.SerializeToElement(consumer) },
+            { AltinnCoreClaimTypes.Org, org },
+            { AltinnCoreClaimTypes.OrgNumber, orgNumber },
+            { AltinnCoreClaimTypes.AuthenticateMethod, "maskinporten" },
+            { AltinnCoreClaimTypes.AuthenticationLevel, "3" },
+            { "jti", Guid.NewGuid().ToString() }
+        };
+
+        return payload;
+    }
+
+    public async Task<string> GetSystemUserToken(
+        string systemId,
+        string systemUserId,
+        string? scope = null
+    )
+    {
+        var testData = await _testDataService.GetTestData();
+        
+        // Find the system user by ID
+        var systemUser = testData.Authorization.SystemUsers.Values.FirstOrDefault(su => su.Id == systemUserId);
+        if (systemUser == null)
+        {
+            var availableSystemUsers = testData.Authorization.SystemUsers.Values.Select(su => su.Id).ToList();
+            throw new InvalidOperationException($"SystemUser with ID '{systemUserId}' not found in test data. Available system users: {string.Join(", ", availableSystemUsers)}");
+        }
+        
+        // Validate that the system user belongs to the specified system
+        if (systemUser.SystemId != systemId)
+        {
+            throw new InvalidOperationException($"SystemUser '{systemUserId}' belongs to system '{systemUser.SystemId}', but '{systemId}' was requested");
+        }
+        
+        // Get supplier org number from system ID
+        var system = testData.Authorization.Systems.Values.FirstOrDefault(s => s.Id == systemId);
+        if (system == null)
+        {
+            var availableSystems = testData.Authorization.Systems.Values.Select(s => s.Id).ToList();
+            throw new InvalidOperationException($"System with ID '{systemId}' not found in test data. Available systems: {string.Join(", ", availableSystems)}");
+        }
+        
+        var supplierOrgNumber = systemId.Split('_')[0];
+
+        var payload = GetSystemUserPayload(systemId, systemUserId, systemUser.OrgNumber, supplierOrgNumber, scope ?? DefaultOrgScope);
+        
+        return _authenticationService.GenerateToken(payload);
+    }
+
+    public static JwtPayload GetSystemUserPayload(
+        string systemId,
+        string systemUserId,
+        string systemUserOrgNumber,
+        string supplierOrgNumber,
+        string scope
+    )
+    {
+        string iss = "https://platform.tt02.altinn.no/authentication/api/v1/openid/";
+
+        var scopes = new HashSet<string>(scope.Split(' ', StringSplitOptions.RemoveEmptyEntries));
+        if (scopes.Any(s => s.StartsWith("altinn:serviceowner/")))
+            throw new InvalidOperationException("System user tokens cannot have serviceowner scopes");
+
+        var payload = new JwtPayload
+        {
+            { "iss", iss },
+            { "token_type", "Bearer" },
+            { "scope", scope },
+            { "client_id", Guid.NewGuid().ToString() },
+            { "jti", Guid.NewGuid().ToString() },
+            { AltinnCoreClaimTypes.OrgNumber, supplierOrgNumber },
+            { AltinnCoreClaimTypes.AuthenticateMethod, "maskinporten" },
+            { AltinnCoreClaimTypes.AuthenticationLevel, "3" },
+        };
+
+        AuthorizationDetailsClaim authorizationDetails = new SystemUserAuthorizationDetailsClaim(
+            [Guid.Parse(systemUserId)],
+            systemId,
+            new OrgClaim(
+                "iso6523-actorid-upis",
+                $"0192:{systemUserOrgNumber}"
+            )
+        );
+
+        var consumer = new OrgClaim(
+            "iso6523-actorid-upis",
+            $"0192:{supplierOrgNumber}"
+        );
+
+        payload.Add("authorization_details", JsonSerializer.SerializeToElement(authorizationDetails));
+        payload.Add("consumer", JsonSerializer.SerializeToElement(consumer));
+
+        return payload;
+    }
+
+
+    public async Task<object> GetInfo()
+    {
+        var testData = await _testDataService.GetTestData();
+        
+        var info = new
+        {
+            AuthenticationTypes = new[]
+            {
+                new { Value = 1, Name = "User", Description = "Regular user with BankID authentication" },
+                new { Value = 2, Name = "SelfIdentifiedUser", Description = "User without SSN/D-number" },
+                new { Value = 3, Name = "Org", Description = "Organization token via Maskinporten" },
+                new { Value = 4, Name = "SystemUser", Description = "System user token with authorization details" },
+                new { Value = 5, Name = "ServiceOwner", Description = "Service owner token with special scopes" }
+            },
+            AvailableTestData = new
+            {
+                Users = testData.Profile.User.Values.Select(u => new { u.UserId, u.UserName, u.PartyId }).ToArray(),
+                Organizations = testData.Register.Org.Keys.ToArray(),
+                SystemUsers = testData.Authorization.SystemUsers.Values.Select(su => new { su.Id, su.SystemId, su.OrgNumber }).ToArray(),
+                Systems = testData.Authorization.Systems.Values.Select(s => new { s.Id, s.Name }).ToArray()
+            },
+            DefaultScopes = new
+            {
+                ServiceOwner = DefaultServiceOwnerScope,
+                Org = DefaultOrgScope,
+                User = DefaultUserScope
+            }
+        };
+
+        return info;
+    }
+
+    private static (int UserId, int PartyId) ValidateAndResolveUserIds(TestDataModel testData, int? userId, int? partyId)
+    {
+        var users = testData.Profile.User.Values.ToList();
+        
+        if (users.Count == 0)
+        {
+            throw new InvalidOperationException("No users found in test data");
+        }
+
+        // Case 1: Both userId and partyId provided - validate both exist and user can represent the party
+        if (userId.HasValue && partyId.HasValue)
+        {
+            var user = users.FirstOrDefault(u => u.UserId == userId.Value);
+            if (user is null)
+            {
+                throw new InvalidOperationException($"User with ID {userId.Value} not found in test data. Available users: {string.Join(", ", users.Select(u => u.UserId))}");
+            }
+            
+            // Check if user can represent the requested party
+            var userPartyList = testData.Authorization.PartyList.GetValueOrDefault(userId.Value.ToString(), new List<Party>());
+            var canRepresentParty = userPartyList.Any(p => p.PartyId == partyId.Value);
+            
+            if (!canRepresentParty)
+            {
+                var availableParties = userPartyList.Select(p => p.PartyId).ToList();
+                throw new InvalidOperationException($"User {userId.Value} cannot represent PartyId {partyId.Value}. Available parties for this user: {string.Join(", ", availableParties)}");
+            }
+            
+            return (userId.Value, partyId.Value);
+        }
+        
+        // Case 2: Only userId provided - find user and use their primary partyId (or first available party)
+        if (userId.HasValue)
+        {
+            var user = users.FirstOrDefault(u => u.UserId == userId.Value);
+            if (user is null)
+            {
+                throw new InvalidOperationException($"User with ID {userId.Value} not found in test data. Available users: {string.Join(", ", users.Select(u => u.UserId))}");
+            }
+            
+            // Check if user has parties they can represent
+            var userPartyList = testData.Authorization.PartyList.GetValueOrDefault(userId.Value.ToString(), new List<Party>());
+            if (userPartyList.Count > 0)
+            {
+                // Use first party from party list (most common case)
+                var firstParty = userPartyList.First();
+                return (userId.Value, firstParty.PartyId);
+            }
+            else
+            {
+                // Fallback to user's own partyId if no party list exists
+                return (userId.Value, user.PartyId);
+            }
+        }
+        
+        // Case 3: Only partyId provided - find a user who can represent that party
+        if (partyId.HasValue)
+        {
+            // First check in party lists (users representing other parties)
+            foreach (var kvp in testData.Authorization.PartyList)
+            {
+                if (int.TryParse(kvp.Key, out var userIdFromPartyList))
+                {
+                    var userParties = kvp.Value;
+                    if (userParties.Any(p => p.PartyId == partyId.Value))
+                    {
+                        return (userIdFromPartyList, partyId.Value);
+                    }
+                }
+            }
+            
+            // Fallback: check if any user has this as their own partyId
+            var user = users.FirstOrDefault(u => u.PartyId == partyId.Value);
+            if (user is not null)
+            {
+                return (user.UserId, partyId.Value);
+            }
+            
+            // Get all available parties for better error message
+            var allAvailableParties = new List<int>();
+            allAvailableParties.AddRange(users.Select(u => u.PartyId));
+            foreach (var partyList in testData.Authorization.PartyList.Values)
+            {
+                allAvailableParties.AddRange(partyList.Select(p => p.PartyId));
+            }
+            
+            throw new InvalidOperationException($"No user found who can represent PartyId {partyId.Value}. Available parties: {string.Join(", ", allAvailableParties.Distinct().OrderBy(x => x))}");
+        }
+        
+        // Case 4: Neither provided - use first available user and their first available party
+        var firstUser = users.First();
+        var firstUserPartyList = testData.Authorization.PartyList.GetValueOrDefault(firstUser.UserId.ToString(), new List<Party>());
+        
+        if (firstUserPartyList.Count > 0)
+        {
+            // Use first party from party list
+            var firstParty = firstUserPartyList.First();
+            return (firstUser.UserId, firstParty.PartyId);
+        }
+        else
+        {
+            // Use user's own partyId
+            return (firstUser.UserId, firstUser.PartyId);
+        }
+    }
+
+    private static string ValidateAndResolveOrgNumber(TestDataModel testData, string? orgNumber)
+    {
+        var availableOrgs = testData.Register.Org.Keys.ToList();
+        
+        if (availableOrgs.Count == 0)
+        {
+            throw new InvalidOperationException("No organizations found in test data");
+        }
+
+        // If orgNumber provided, validate it exists
+        if (!string.IsNullOrEmpty(orgNumber))
+        {
+            if (!availableOrgs.Contains(orgNumber))
+            {
+                throw new InvalidOperationException($"Organization with number '{orgNumber}' not found in test data. Available organizations: {string.Join(", ", availableOrgs)}");
+            }
+            return orgNumber;
+        }
+
+        // If not provided, use first available
+        return availableOrgs.First();
+    }
+
+}

--- a/src/Services/Authentication/Implementation/TestAuthenticationService.cs
+++ b/src/Services/Authentication/Implementation/TestAuthenticationService.cs
@@ -81,13 +81,12 @@ public class TestAuthenticationService
 
         var payload = new JwtPayload
         {
-            { "iss", DefaultIssuer },
             { "actual_iss", "localtest" },
-            { ClaimTypes.NameIdentifier, $"user-{userId}-{partyId}" },
+            { ClaimTypes.NameIdentifier, userId.ToString() },
             { AltinnCoreClaimTypes.UserId, userId.ToString() },
             { AltinnCoreClaimTypes.PartyID, partyId.ToString() },
             { AltinnCoreClaimTypes.AuthenticateMethod, "BankID" },
-            { AltinnCoreClaimTypes.AuthenticationLevel, authLevel.ToString() },
+            { AltinnCoreClaimTypes.AuthenticationLevel, authLevel },
             { "jti", Guid.NewGuid().ToString() },
             { "scope", scope ?? DefaultUserScope },
         };
@@ -132,14 +131,13 @@ public class TestAuthenticationService
 
         var payload = new JwtPayload
         {
-            { "iss", DefaultIssuer },
             { "actual_iss", "localtest" },
-            { ClaimTypes.NameIdentifier, $"user-{userId}-{partyId}" },
+            { ClaimTypes.NameIdentifier, userId.ToString() },
             { AltinnCoreClaimTypes.UserId, userId.ToString() },
             { AltinnCoreClaimTypes.UserName, username },
             { AltinnCoreClaimTypes.PartyID, partyId.ToString() },
-            { AltinnCoreClaimTypes.AuthenticateMethod, "Mock" },
-            { AltinnCoreClaimTypes.AuthenticationLevel, "0" },
+            { AltinnCoreClaimTypes.AuthenticateMethod, "SelfIdentified" },
+            { AltinnCoreClaimTypes.AuthenticationLevel, 0 },
             { "jti", Guid.NewGuid().ToString() },
             { "scope", scope ?? DefaultUserScope },
         };
@@ -169,7 +167,7 @@ public class TestAuthenticationService
             { "consumer", JsonSerializer.SerializeToElement(consumer) },
             { AltinnCoreClaimTypes.OrgNumber, orgNumber },
             { AltinnCoreClaimTypes.AuthenticateMethod, "maskinporten" },
-            { AltinnCoreClaimTypes.AuthenticationLevel, "3" },
+            { AltinnCoreClaimTypes.AuthenticationLevel, 3 },
             { "jti", Guid.NewGuid().ToString() },
         };
 
@@ -228,7 +226,7 @@ public class TestAuthenticationService
             { AltinnCoreClaimTypes.Org, org },
             { AltinnCoreClaimTypes.OrgNumber, orgNumber },
             { AltinnCoreClaimTypes.AuthenticateMethod, "maskinporten" },
-            { AltinnCoreClaimTypes.AuthenticationLevel, "3" },
+            { AltinnCoreClaimTypes.AuthenticationLevel, 3 },
             { "jti", Guid.NewGuid().ToString() },
         };
 
@@ -295,7 +293,7 @@ public class TestAuthenticationService
             { "jti", Guid.NewGuid().ToString() },
             { AltinnCoreClaimTypes.OrgNumber, supplierOrgNumber },
             { AltinnCoreClaimTypes.AuthenticateMethod, "maskinporten" },
-            { AltinnCoreClaimTypes.AuthenticationLevel, "3" },
+            { AltinnCoreClaimTypes.AuthenticationLevel, 3 },
         };
 
         AuthorizationDetailsClaim authorizationDetails = new SystemUserAuthorizationDetailsClaim(

--- a/src/Services/Authentication/Implementation/TestAuthenticationService.cs
+++ b/src/Services/Authentication/Implementation/TestAuthenticationService.cs
@@ -20,6 +20,7 @@ public class TestAuthenticationService
         "altinn:serviceowner/instances.read altinn:serviceowner/instances.write";
     public const string DefaultOrgScope = "altinn:instances.read altinn:instances.write";
     public const string DefaultUserScope = "altinn:portal/enduser";
+    public const string DefaultIssuer = "https://platform.tt02.altinn.no/authentication/api/v1/openid/";
 
     public TestAuthenticationService(IAuthentication authenticationService, TestDataService testDataService)
     {
@@ -77,10 +78,11 @@ public class TestAuthenticationService
         string? scope = null
     )
     {
-        string iss = "https://platform.tt02.altinn.no/authentication/api/v1/openid/";
 
         var payload = new JwtPayload
         {
+            { "iss", DefaultIssuer },
+            { "actual_iss", "localtest" },
             { ClaimTypes.NameIdentifier, $"user-{userId}-{partyId}" },
             { AltinnCoreClaimTypes.UserId, userId.ToString() },
             { AltinnCoreClaimTypes.PartyID, partyId.ToString() },
@@ -88,8 +90,6 @@ public class TestAuthenticationService
             { AltinnCoreClaimTypes.AuthenticationLevel, authLevel.ToString() },
             { "jti", Guid.NewGuid().ToString() },
             { "scope", scope ?? DefaultUserScope },
-            { "iss", iss },
-            { "islocaltest", "true" }
         };
 
         return payload;
@@ -129,10 +129,11 @@ public class TestAuthenticationService
         string? scope = null
     )
     {
-        string iss = "https://platform.tt02.altinn.no/authentication/api/v1/openid/";
 
         var payload = new JwtPayload
         {
+            { "iss", DefaultIssuer },
+            { "actual_iss", "localtest" },
             { ClaimTypes.NameIdentifier, $"user-{userId}-{partyId}" },
             { AltinnCoreClaimTypes.UserId, userId.ToString() },
             { AltinnCoreClaimTypes.UserName, username },
@@ -141,8 +142,6 @@ public class TestAuthenticationService
             { AltinnCoreClaimTypes.AuthenticationLevel, "0" },
             { "jti", Guid.NewGuid().ToString() },
             { "scope", scope ?? DefaultUserScope },
-            { "iss", iss },
-            { "islocaltest", "true" }
         };
 
         return payload;
@@ -150,7 +149,6 @@ public class TestAuthenticationService
 
     public static JwtPayload GetOrgPayload(string orgNumber, string scope)
     {
-        string iss = "https://platform.tt02.altinn.no/authentication/api/v1/openid/";
 
         var scopes = new HashSet<string>(scope.Split(' ', StringSplitOptions.RemoveEmptyEntries));
         if (scopes.Any(s => s.StartsWith("altinn:serviceowner/")))
@@ -163,7 +161,8 @@ public class TestAuthenticationService
 
         var payload = new JwtPayload
         {
-            { "iss", iss },
+            { "iss", DefaultIssuer },
+            { "actual_iss", "localtest" },
             { "scope", scope },
             { "token_type", "Bearer" },
             { "client_id", Guid.NewGuid().ToString() },
@@ -172,7 +171,6 @@ public class TestAuthenticationService
             { AltinnCoreClaimTypes.AuthenticateMethod, "maskinporten" },
             { AltinnCoreClaimTypes.AuthenticationLevel, "3" },
             { "jti", Guid.NewGuid().ToString() },
-            { "islocaltest", "true" }
         };
 
         return payload;
@@ -209,7 +207,6 @@ public class TestAuthenticationService
         string org
     )
     {
-        const string iss = "https://platform.tt02.altinn.no/authentication/api/v1/openid/";
 
         var scopes = new HashSet<string>(scope.Split(' ', StringSplitOptions.RemoveEmptyEntries));
         if (!scopes.Any(s => s.StartsWith("altinn:serviceowner/")))
@@ -222,7 +219,8 @@ public class TestAuthenticationService
 
         var payload = new JwtPayload
         {
-            { "iss", iss },
+            { "iss", DefaultIssuer },
+            { "actual_iss", "localtest" },
             { "scope", scope },
             { "token_type", "Bearer" },
             { "client_id", Guid.NewGuid().ToString() },
@@ -232,7 +230,6 @@ public class TestAuthenticationService
             { AltinnCoreClaimTypes.AuthenticateMethod, "maskinporten" },
             { AltinnCoreClaimTypes.AuthenticationLevel, "3" },
             { "jti", Guid.NewGuid().ToString() },
-            { "islocaltest", "true" }
         };
 
         return payload;
@@ -283,7 +280,6 @@ public class TestAuthenticationService
         string scope
     )
     {
-        string iss = "https://platform.tt02.altinn.no/authentication/api/v1/openid/";
 
         var scopes = new HashSet<string>(scope.Split(' ', StringSplitOptions.RemoveEmptyEntries));
         if (scopes.Any(s => s.StartsWith("altinn:serviceowner/")))
@@ -291,7 +287,8 @@ public class TestAuthenticationService
 
         var payload = new JwtPayload
         {
-            { "iss", iss },
+            { "iss", DefaultIssuer },
+            { "actual_iss", "localtest" },
             { "token_type", "Bearer" },
             { "scope", scope },
             { "client_id", Guid.NewGuid().ToString() },
@@ -299,7 +296,6 @@ public class TestAuthenticationService
             { AltinnCoreClaimTypes.OrgNumber, supplierOrgNumber },
             { AltinnCoreClaimTypes.AuthenticateMethod, "maskinporten" },
             { AltinnCoreClaimTypes.AuthenticationLevel, "3" },
-            { "islocaltest", "true" }
         };
 
         AuthorizationDetailsClaim authorizationDetails = new SystemUserAuthorizationDetailsClaim(

--- a/src/Services/Authentication/Interface/IAuthentication.cs
+++ b/src/Services/Authentication/Interface/IAuthentication.cs
@@ -1,6 +1,7 @@
 #nullable enable
 using System.Security.Claims;
 using System.Threading.Tasks;
+using System.IdentityModel.Tokens.Jwt;
 using Altinn.Platform.Profile.Models;
 
 namespace LocalTest.Services.Authentication.Interface
@@ -13,6 +14,13 @@ namespace LocalTest.Services.Authentication.Interface
         /// <param name="principal">The claims principal.</param>
         /// <returns>JWT token</returns>
         public string GenerateToken(ClaimsPrincipal principal);
+
+        /// <summary>
+        /// Creates a JWT token based on JWT payload.
+        /// </summary>
+        /// <param name="payload">The JWT payload.</param>
+        /// <returns>JWT token</returns>
+        public string GenerateToken(JwtPayload payload);
 
         /// <summary>
         /// Generate a JWT token with claims for an application owner org

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -121,6 +121,7 @@ namespace LocalTest
 
             // Shared auth services
             services.AddSingleton<IAuthentication, AuthenticationService>();
+            services.AddSingleton<TestAuthenticationService>();
             services.AddTransient<IAuthorizationHandler, AppAccessHandler>();
             services.AddTransient<IAuthorizationHandler, ScopeAccessHandler>();
             services.AddTransient<IAuthorizationHandler, StorageAccessHandler>();


### PR DESCRIPTION
## Description
Adds a controller that implements test authentication similar to `TestAuthentication` in app-lib. These have been compared to "real" tokens so that format and encoding is the same. I've added a `actual_iss` claim as a simple way for app-lib to not do the `FromLocaltest` token parsing for these

Depends on https://github.com/Altinn/app-localtest/pull/170

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
