### PR TITLE
.dockerignore for container builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git/
+**/[b|B]in/
+**/[O|o]bj/
+k6/
+scripts/
+infra/
+.vscode/


### PR DESCRIPTION
## Description
Noticed this missing as one of my test machines errored out on trying to pack stuff within `.git/`. It is unclear why, but we should have a decent context regardless

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
