### PR TITLE
Remove 'altinn:serviceowner/' scope requirement for serviceowner tokens

### DIFF
--- a/src/Services/Authentication/Implementation/TestAuthenticationService.cs
+++ b/src/Services/Authentication/Implementation/TestAuthenticationService.cs
@@ -148,10 +148,6 @@ public class TestAuthenticationService
     public static JwtPayload GetOrgPayload(string orgNumber, string scope)
     {
 
-        var scopes = new HashSet<string>(scope.Split(' ', StringSplitOptions.RemoveEmptyEntries));
-        if (scopes.Any(s => s.StartsWith("altinn:serviceowner/")))
-            throw new InvalidOperationException("Org token cannot have serviceowner scopes");
-
         var consumer = new OrgClaim(
             "iso6523-actorid-upis",
             $"0192:{orgNumber}"
@@ -205,10 +201,6 @@ public class TestAuthenticationService
         string org
     )
     {
-
-        var scopes = new HashSet<string>(scope.Split(' ', StringSplitOptions.RemoveEmptyEntries));
-        if (!scopes.Any(s => s.StartsWith("altinn:serviceowner/")))
-            throw new InvalidOperationException("Service owner token must have serviceowner scopes");
 
         var consumer = new OrgClaim(
             "iso6523-actorid-upis",
@@ -278,11 +270,6 @@ public class TestAuthenticationService
         string scope
     )
     {
-
-        var scopes = new HashSet<string>(scope.Split(' ', StringSplitOptions.RemoveEmptyEntries));
-        if (scopes.Any(s => s.StartsWith("altinn:serviceowner/")))
-            throw new InvalidOperationException("System user tokens cannot have serviceowner scopes");
-
         var payload = new JwtPayload
         {
             { "iss", DefaultIssuer },


### PR DESCRIPTION
## Description
Service owners can soon define custom scopes, so we need to relax this

## Related Issue(s)
- https://github.com/Altinn/app-lib-dotnet/issues/1288

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
