### PR TITLE
Fixes issue with Grafana vs. local Cypress testing

### DIFF
--- a/src/Controllers/InfraController.cs
+++ b/src/Controllers/InfraController.cs
@@ -14,8 +14,8 @@ public class InfraController : ControllerBase
     private readonly GeneralSettings _generalSettings;
 
     public InfraController(
-        ILogger<InfraController> logger, 
-        IHttpClientFactory httpClientFactory, 
+        ILogger<InfraController> logger,
+        IHttpClientFactory httpClientFactory,
         IOptions<LocalPlatformSettings> localPlatformSettings,
         IOptions<GeneralSettings> generalSettings
     )
@@ -37,14 +37,19 @@ public class InfraController : ControllerBase
             var baseUrl = _localPlatformSettings.LocalGrafanaUrl ?? $"{_generalSettings.BaseUrl}/grafana";
             var url = $"{baseUrl}/api/health";
             var response = await client.GetAsync(url, cancellationToken);
-            if (response.IsSuccessStatusCode)
-            {
-                return Ok();
-            }
-            else
-            {
-                throw new Exception("Unexpected status code: " + response.StatusCode);
-            }
+
+            return response.IsSuccessStatusCode
+                ? Ok()
+                : throw new Exception("Unexpected status code: " + response.StatusCode);
+        }
+        catch (HttpRequestException ex)
+            when (ex.InnerException?.Message.Contains(
+                    "name does not resolve",
+                    StringComparison.OrdinalIgnoreCase
+                ) is true
+            )
+        {
+            return StatusCode(StatusCodes.Status204NoContent);
         }
         catch (Exception ex)
         {

--- a/src/Controllers/InfraController.cs
+++ b/src/Controllers/InfraController.cs
@@ -51,6 +51,10 @@ public class InfraController : ControllerBase
         {
             return StatusCode(StatusCodes.Status204NoContent);
         }
+        catch (TaskCanceledException)
+        {
+            return StatusCode(StatusCodes.Status204NoContent);
+        }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Error while checking health of {container}", "grafana");

--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -56,18 +56,27 @@
         window.onload = evt => {
             const el = document.querySelector('nav .grafana-item');
             if (!el) throw new Error('Navbar grafana-item not found');
-            
+
+            const controller = new AbortController();
+            window.addEventListener('beforeunload', () => {
+                controller.abort();
+            });
+
+
             const updateGrafanaItem = () => {
-                fetch('/Home/Infra/Grafana')
+                fetch('/Home/Infra/Grafana', { signal: controller.signal })
                     .then(res => {
-                        if (res.status === 200)
+                        if (res.status === 200) 
                             el.classList.remove('d-none');
-                        else
+                         else 
                             el.classList.add('d-none');
                     })
                     .catch(err => {
-                        console.error('Failed to fetch Grafana status', err);
-                        el.classList.add('d-none');
+                        if (err.name === 'AbortError')
+                            console.log('Aborted grafana request because navigated away');
+                        else
+                            console.error('Failed to fetch Grafana status', err);
+                            el.classList.add('d-none');
                     });
             };
 

--- a/src/Views/Shared/_Layout.cshtml
+++ b/src/Views/Shared/_Layout.cshtml
@@ -60,7 +60,7 @@
             const updateGrafanaItem = () => {
                 fetch('/Home/Infra/Grafana')
                     .then(res => {
-                        if (res.ok)
+                        if (res.status === 200)
                             el.classList.remove('d-none');
                         else
                             el.classList.add('d-none');


### PR DESCRIPTION
## Description
The index page polls `/Home/Infra/Grafana` to check if Grafan is running. This check returns a 503 error if it is unable to connect to Grafana, which in itself makes sense, but is causing Cypress tests to fail when running locally.

As a compromise/solution, this PR simply returns 204 when we have determined that the service is not running -- and alters the consumer slightly to look for 200 specifically instead of "all OK replies" from the infra controller.