### PR TITLE
chore: remove old pdf, add new

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,31 +30,21 @@ services:
       - ./loadbalancer/templates:/etc/nginx/templates/:ro
       - ./loadbalancer/www:/www/:ro
 
-  altinn_platform_pdf:
-    container_name: altinn-pdf
-    platform: linux/amd64
-    image: ghcr.io/altinn/altinn-pdf:latest
+  altinn_pdf3:
+    container_name: localtest-pdf3
+    image: ghcr.io/altinn/altinn-studio/runtime-pdf3-worker:18d798ea03
     restart: always
     networks:
       - altinntestlocal_network
     ports:
-      - "5070:5070"
-    extra_hosts:
-      - "host.docker.internal:host-gateway"
-
-  altinn_pdf_service:
-    container_name: altinn-pdf-service
-    image: browserless/chrome:1-puppeteer-21.3.6
-    restart: always
-    networks:
-      - altinntestlocal_network
-    ports:
-      - "5300:3000"
+      - "5300:5031"
+    environment:
+      - TZ=Europe/Oslo
+      - PDF3_ENVIRONMENT=localtest
+      - PDF3_QUEUE_SIZE=3
     extra_hosts:
       - "${TEST_DOMAIN:-local.altinn.cloud}:host-gateway"
       - "host.containers.internal:host-gateway"
-    environment:
-      - TZ=Europe/Oslo
 
   altinn_localtest:
     container_name: localtest

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -32,26 +32,18 @@ services:
       - ./loadbalancer/templates/:/etc/nginx/templates/:ro,z
       - ./loadbalancer/www/:/www/:ro,z
 
-  altinn_platform_pdf:
-    container_name: altinn-pdf
-    platform: linux/amd64
-    image: ghcr.io/altinn/altinn-pdf:latest
+  altinn_pdf3:
+    container_name: localtest-pdf3
+    image: ghcr.io/altinn/altinn-studio/runtime-pdf3-worker:18d798ea03
     restart: always
     networks:
       - altinntestlocal_network
     ports:
-      - "5070:5070"
-
-  altinn_pdf_service:
-    container_name: altinn-pdf-service
-    image: browserless/chrome:1-puppeteer-21.3.6
-    restart: always
-    networks:
-      - altinntestlocal_network
-    ports:
-      - "5300:3000"
+      - "5300:5031"
     environment:
       - TZ=Europe/Oslo
+      - PDF3_ENVIRONMENT=localtest
+      - PDF3_QUEUE_SIZE=3
 
   altinn_localtest:
     container_name: localtest


### PR DESCRIPTION
## Description

- team app migration have ensured no apps use old PDF (the Java thing), core has deleted the code
- browserless container is replaced with the new worker in localtest mode on the same port

## Related Issue(s)
- N/A

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
