### PR TITLE
fix: Use network alias for loadbalancer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,9 @@ services:
         NGINX_VERSION: 1.25.3
     restart: always
     networks:
-      - altinntestlocal_network
+      altinntestlocal_network:
+        aliases:
+          - ${TEST_DOMAIN:-local.altinn.cloud}
     ports:
       - "${ALTINN3LOCAL_PORT:-80}:80"
     environment:
@@ -42,9 +44,6 @@ services:
       - TZ=Europe/Oslo
       - PDF3_ENVIRONMENT=localtest
       - PDF3_QUEUE_SIZE=3
-    extra_hosts:
-      - "${TEST_DOMAIN:-local.altinn.cloud}:host-gateway"
-      - "host.containers.internal:host-gateway"
 
   altinn_localtest:
     container_name: localtest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This PR adds a network alias in the docker-compose file to make `local.altinn.cloud` resolve to the loadbalancer. This fixes an issue where there was no connection between the app and the pdf3 service on Windows/WSL when using a custom `ALTINN3LOCAL_PORT`.

## Summary by Claude
Fixed PDF generation failure when running localtest on non-standard ports (e.g., 8642) by adding a network alias to the load balancer service. The PDF service's headless browser was unable to resolve local.altinn.cloud to the correct internal Docker endpoint, causing timeouts when attempting to render pages. By adding alias `${TEST_DOMAIN:local.altinn.cloud}` to the load balancer's network configuration, the PDF service can now correctly resolve and access the load balancer on port 80 (internal Docker port), regardless of the external port mapping.

## Verification
- [x] **Your** code builds clean without any errors or warnings
- [x] Manual testing done (required)
- [x] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [x] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
