### PR TITLE
Re enable filescan in localtest

### DIFF
--- a/src/Controllers/Storage/DataController.cs
+++ b/src/Controllers/Storage/DataController.cs
@@ -465,9 +465,15 @@ public class DataController : ControllerBase
         Stream theStream = streamAndDataElement.Stream;
         DataElement newData = streamAndDataElement.DataElement;
 
+#if LOCALTEST
+        newData.FileScanResult = dataTypeDefinition.EnableFileScan
+            ? FileScanResult.Clean
+            : FileScanResult.NotApplicable;
+#else
         newData.FileScanResult = dataTypeDefinition.EnableFileScan
             ? FileScanResult.Pending
             : FileScanResult.NotApplicable;
+#endif
 
         if (theStream == null)
         {
@@ -660,9 +666,15 @@ public class DataController : ControllerBase
 
         if (blobSize > 0)
         {
+#if LOCALTEST
+            FileScanResult scanResult = dataTypeDefinition.EnableFileScan
+                ? FileScanResult.Clean
+                : FileScanResult.NotApplicable;
+#else
             FileScanResult scanResult = dataTypeDefinition.EnableFileScan
                 ? FileScanResult.Pending
                 : FileScanResult.NotApplicable;
+#endif
 
             updatedProperties.Add("/fileScanResult", scanResult);
 


### PR DESCRIPTION
#98 changed functionality to always set files to "clean" when using localtest, but #195 inadvertantly reverted the changes.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue(s)
- #{issue number}

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
