### PR TITLE
Update version endpoint to return '4'

### DIFF
--- a/src/Controllers/HomeController.cs
+++ b/src/Controllers/HomeController.cs
@@ -107,7 +107,7 @@ namespace LocalTest.Controllers
         [HttpGet("/Home/Localtest/Version")]
         public IActionResult Version()
         {
-            return Ok("3");
+            return Ok("4");
         }
 
         [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]


### PR DESCRIPTION
After fixing the regression, we might want to have a new version number in case lots of users gets affected.

Bumping the number now, so all users that pull localtest gets the new number. We can bump the requirement in app-lib later if this hurts many.

## Related Issue(s)
- #199 

## Verification
- [ ] **Your** code builds clean without any errors or warnings
- [ ] Manual testing done (required)
- [ ] Relevant automated test added (if you find this hard, leave it and we'll help out)
- [ ] All tests run green

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
