### PR TITLE
Flip default nullable behaviour

### DIFF
--- a/src/Clients/CdnAltinnOrgs/AltinnOrgsClient.cs
+++ b/src/Clients/CdnAltinnOrgs/AltinnOrgsClient.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;

--- a/src/Clients/CdnAltinnOrgs/Models.cs
+++ b/src/Clients/CdnAltinnOrgs/Models.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 

--- a/src/Clients/IOndemandClient.cs
+++ b/src/Clients/IOndemandClient.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.IO;
 using System.Threading.Tasks;
 

--- a/src/Clients/IPartiesWithInstancesClient.cs
+++ b/src/Clients/IPartiesWithInstancesClient.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Threading.Tasks;
 
 namespace Altinn.Platform.Storage.Clients

--- a/src/Clients/OnDemandClient.cs
+++ b/src/Clients/OnDemandClient.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.IO;
 using System.Threading.Tasks;
 

--- a/src/Clients/PartiesWithInstancesClient.cs
+++ b/src/Clients/PartiesWithInstancesClient.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Threading.Tasks;
 
 namespace Altinn.Platform.Storage.Clients

--- a/src/Configuration/Authentication/GeneralSettings.cs
+++ b/src/Configuration/Authentication/GeneralSettings.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 
 namespace Altinn.Platform.Authentication.Configuration

--- a/src/Configuration/GeneralSettings.cs
+++ b/src/Configuration/GeneralSettings.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Configuration/LocalPlatformSettings.cs
+++ b/src/Configuration/LocalPlatformSettings.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.IO;
 
 namespace LocalTest.Configuration

--- a/src/Configuration/Storage/GeneralSettings.cs
+++ b/src/Configuration/Storage/GeneralSettings.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 

--- a/src/Configuration/WolverineSettings.cs
+++ b/src/Configuration/WolverineSettings.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 namespace Altinn.Platform.Storage.Configuration;
 
 /// <summary>

--- a/src/Constants/Authorization/AuthzConstants.cs
+++ b/src/Constants/Authorization/AuthzConstants.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 namespace Altinn.Platform.Storage.Helpers
 {
     /// <summary>

--- a/src/Constants/Authorization/XacmlRequestAttribute.cs
+++ b/src/Constants/Authorization/XacmlRequestAttribute.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 namespace Altinn.Platform.Authorization.Constants
 {
     /// <summary>

--- a/src/Constants/LocalTestApi.cs
+++ b/src/Constants/LocalTestApi.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 namespace LocalTest.Constants
 {
     public static class LocalTestApi

--- a/src/Controllers/AccessManagement/AppsInstanceDelegationController.cs
+++ b/src/Controllers/AccessManagement/AppsInstanceDelegationController.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using System.Text.Json.Serialization;

--- a/src/Controllers/Authentication/AuthenticationController.cs
+++ b/src/Controllers/Authentication/AuthenticationController.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Security.Claims;

--- a/src/Controllers/Authentication/OpenIdController.cs
+++ b/src/Controllers/Authentication/OpenIdController.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Security.Cryptography;

--- a/src/Controllers/Authorization/DecisionController.cs
+++ b/src/Controllers/Authorization/DecisionController.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/Controllers/Authorization/PartiesController.cs
+++ b/src/Controllers/Authorization/PartiesController.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Altinn.Platform.Authorization.Services.Interface;

--- a/src/Controllers/Authorization/RolesController.cs
+++ b/src/Controllers/Authorization/RolesController.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 
 using Altinn.Platform.Authorization.Services.Interface;
 using Altinn.Platform.Storage.Helpers;

--- a/src/Controllers/DebugUsersController.cs
+++ b/src/Controllers/DebugUsersController.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
 

--- a/src/Controllers/Events/AppController.cs
+++ b/src/Controllers/Events/AppController.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using Altinn.Platform.Events.Models;
 using Altinn.Platform.Events.Repository;
 

--- a/src/Controllers/Events/EventsController.cs
+++ b/src/Controllers/Events/EventsController.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using Altinn.Platform.Events.Models;
 using Altinn.Platform.Events.Repository;
 

--- a/src/Controllers/Events/SubscriptionController.cs
+++ b/src/Controllers/Events/SubscriptionController.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using Altinn.Platform.Events.Models;
 using Altinn.Platform.Events.Services.Interfaces;
 using AutoMapper;

--- a/src/Controllers/FrontendVersionController.cs
+++ b/src/Controllers/FrontendVersionController.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Text.Json;
 
 using Microsoft.AspNetCore.Mvc;

--- a/src/Controllers/HomeController.cs
+++ b/src/Controllers/HomeController.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Diagnostics;
 using System.Xml;
 

--- a/src/Controllers/InfraController.cs
+++ b/src/Controllers/InfraController.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using LocalTest.Configuration;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;

--- a/src/Controllers/Profile/UsersController.cs
+++ b/src/Controllers/Profile/UsersController.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Linq;
 using System.Threading.Tasks;
 using Altinn.Platform.Profile.Models;

--- a/src/Controllers/Register/OrganizationsController.cs
+++ b/src/Controllers/Register/OrganizationsController.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Threading.Tasks;
 
 using Altinn.Platform.Register.Models;

--- a/src/Controllers/Register/PartiesController.cs
+++ b/src/Controllers/Register/PartiesController.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Threading.Tasks;
 
 using Altinn.Platform.Register.Filters;

--- a/src/Controllers/Register/PersonsController.cs
+++ b/src/Controllers/Register/PersonsController.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Linq;
 using System.Security.Claims;

--- a/src/Controllers/ResourceRegistry/ResourceController.cs
+++ b/src/Controllers/ResourceRegistry/ResourceController.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using Altinn.ResourceRegistry.Core;
 using Altinn.ResourceRegistry.Core.Extensions;
 using Altinn.ResourceRegistry.Core.Models;

--- a/src/Controllers/Storage/ApplicationsController.cs
+++ b/src/Controllers/Storage/ApplicationsController.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Net;

--- a/src/Controllers/Storage/DataController.cs
+++ b/src/Controllers/Storage/DataController.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Controllers/Storage/DataLockController.cs
+++ b/src/Controllers/Storage/DataLockController.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/Controllers/Storage/InstanceEventsController.cs
+++ b/src/Controllers/Storage/InstanceEventsController.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/Controllers/Storage/InstanceLockController.cs
+++ b/src/Controllers/Storage/InstanceLockController.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Diagnostics;
 using Altinn.Platform.Storage.Authorization;
 using Altinn.Platform.Storage.Helpers;

--- a/src/Controllers/Storage/InstancesController.cs
+++ b/src/Controllers/Storage/InstancesController.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Controllers/Storage/ProcessController.cs
+++ b/src/Controllers/Storage/ProcessController.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Controllers/Storage/SignController.cs
+++ b/src/Controllers/Storage/SignController.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Controllers/Storage/TextsController.cs
+++ b/src/Controllers/Storage/TextsController.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Threading.Tasks;
 using Altinn.Platform.Storage.Helpers;

--- a/src/Controllers/StorageExplorerController.cs
+++ b/src/Controllers/StorageExplorerController.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using Microsoft.AspNetCore.Mvc;
 
 namespace LocalTest.Controllers;

--- a/src/Controllers/TenorUsersController.cs
+++ b/src/Controllers/TenorUsersController.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Text.Json;
 
 using Microsoft.AspNetCore.Mvc;

--- a/src/Controllers/TestAuthenticationController.cs
+++ b/src/Controllers/TestAuthenticationController.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using Microsoft.AspNetCore.Mvc;
 using LocalTest.Models.Authentication;
 using LocalTest.Services.Authentication.Implementation;

--- a/src/Extensions/ResourceRegistry/StringExtensions.cs
+++ b/src/Extensions/ResourceRegistry/StringExtensions.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.IO;
 using System.Linq;

--- a/src/Extensions/Storage/ContentDispositionHeaderValueExtensions.cs
+++ b/src/Extensions/Storage/ContentDispositionHeaderValueExtensions.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 

--- a/src/Extensions/Storage/DataTypeExtensions.cs
+++ b/src/Extensions/Storage/DataTypeExtensions.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using Altinn.Platform.Storage.Authorization;
 using Altinn.Platform.Storage.Interface.Models;
 

--- a/src/Extensions/Storage/StringExtensions.cs
+++ b/src/Extensions/Storage/StringExtensions.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.IO;
 using System.Linq;

--- a/src/Filters/ProxyMiddleware.cs
+++ b/src/Filters/ProxyMiddleware.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Diagnostics;
 using System.Net;
 using System.Text.RegularExpressions;

--- a/src/Filters/ValidateModelStateAttribute.cs
+++ b/src/Filters/ValidateModelStateAttribute.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 
 using Microsoft.AspNetCore.Mvc;

--- a/src/Helpers/ContentDispositionHeaderValueExtensions.cs
+++ b/src/Helpers/ContentDispositionHeaderValueExtensions.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 

--- a/src/Helpers/SortedHtmlDirectoryFormatter.cs
+++ b/src/Helpers/SortedHtmlDirectoryFormatter.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Text.Encodings.Web;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.FileProviders;

--- a/src/Helpers/Storage/AuthorizationHelper.cs
+++ b/src/Helpers/Storage/AuthorizationHelper.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Helpers/Storage/ClaimsPrincipalExtensions.cs
+++ b/src/Helpers/Storage/ClaimsPrincipalExtensions.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System;
 using System.Security.Claims;
 using System.Text.Json;

--- a/src/Helpers/Storage/DataElementHelper.cs
+++ b/src/Helpers/Storage/DataElementHelper.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Helpers/Storage/DateTimeHelper.cs
+++ b/src/Helpers/Storage/DateTimeHelper.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Globalization;
 

--- a/src/Helpers/Storage/DisableFormValueModelBindingAttribute.cs
+++ b/src/Helpers/Storage/DisableFormValueModelBindingAttribute.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.ModelBinding;

--- a/src/Helpers/Storage/InstanceHelper.cs
+++ b/src/Helpers/Storage/InstanceHelper.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;

--- a/src/Helpers/Storage/LanguageHelper.cs
+++ b/src/Helpers/Storage/LanguageHelper.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Http;
 

--- a/src/Helpers/Storage/MessageBoxInstance.cs
+++ b/src/Helpers/Storage/MessageBoxInstance.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;

--- a/src/Helpers/Storage/MultipartRequestHelper.cs
+++ b/src/Helpers/Storage/MultipartRequestHelper.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Helpers/Storage/OrgDataContext.cs
+++ b/src/Helpers/Storage/OrgDataContext.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 
 namespace Altinn.Platform.Storage.Helpers

--- a/src/Helpers/Storage/ProcessHelper.cs
+++ b/src/Helpers/Storage/ProcessHelper.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Helpers/Storage/QueryResponse.cs
+++ b/src/Helpers/Storage/QueryResponse.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Collections.Generic;
 using Newtonsoft.Json;
 

--- a/src/Helpers/Storage/SblInstanceEvent.cs
+++ b/src/Helpers/Storage/SblInstanceEvent.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using Altinn.Platform.Storage.Interface.Models;
 using Newtonsoft.Json;

--- a/src/Helpers/Storage/StringHelper.cs
+++ b/src/Helpers/Storage/StringHelper.cs
@@ -1,4 +1,6 @@
-﻿using System;
+#nullable disable
+
+using System;
 
 namespace Altinn.Platform.Storage.Helpers;
 

--- a/src/Helpers/StringExtensions.cs
+++ b/src/Helpers/StringExtensions.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.IO;
 using System.Linq;

--- a/src/LocalTest.csproj
+++ b/src/LocalTest.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>56f36ce2-b44b-415e-a8a5-f399a76e35b9</UserSecretsId>
     <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
 
     <!-- Allow copied code to use #if LOCALTEST to maintain changes for localtest from core services -->
     <DefineConstants>$(DefineConstants);LOCALTEST</DefineConstants>

--- a/src/Models/Authentication/AuthenticationTypes.cs
+++ b/src/Models/Authentication/AuthenticationTypes.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 namespace LocalTest.Models.Authentication;
 
 public enum AuthenticationTypes

--- a/src/Models/Authentication/CustomClaim.cs
+++ b/src/Models/Authentication/CustomClaim.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+#nullable disable
+
+using System.Text.Json.Serialization;
 
 namespace Altinn.Platform.Authentication.Model
 {

--- a/src/Models/Authentication/DiscoveryDocument.cs
+++ b/src/Models/Authentication/DiscoveryDocument.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Text.Json.Serialization;
 
 namespace Altinn.Platform.Authentication.Model

--- a/src/Models/Authentication/JwkDocument.cs
+++ b/src/Models/Authentication/JwkDocument.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 

--- a/src/Models/Authentication/JwksDocument.cs
+++ b/src/Models/Authentication/JwksDocument.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 

--- a/src/Models/Authorization/Role.cs
+++ b/src/Models/Authorization/Role.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using Newtonsoft.Json;
 using System.Text.Json.Serialization;
 

--- a/src/Models/Authorization/XacmlRequestApiModel.cs
+++ b/src/Models/Authorization/XacmlRequestApiModel.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 namespace Altinn.Platform.Authorization.ModelBinding
 {
     /// <summary>

--- a/src/Models/Authorization/XacmlRequestApiModelBinder.cs
+++ b/src/Models/Authorization/XacmlRequestApiModelBinder.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.IO;
 using System.Threading.Tasks;

--- a/src/Models/Authorization/XacmlRequestApiModelBinderProvider.cs
+++ b/src/Models/Authorization/XacmlRequestApiModelBinderProvider.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 

--- a/src/Models/Authorization/XacmlResourceAttributes.cs
+++ b/src/Models/Authorization/XacmlResourceAttributes.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 namespace Altinn.Platform.Authorization.Models
 {
     /// <summary>

--- a/src/Models/ErrorViewModel.cs
+++ b/src/Models/ErrorViewModel.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 
 namespace LocalTest.Models

--- a/src/Models/Events/CloudEvent.cs
+++ b/src/Models/Events/CloudEvent.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using Newtonsoft.Json;
 
 namespace Altinn.Platform.Events.Models

--- a/src/Models/Events/ServiceError.cs
+++ b/src/Models/Events/ServiceError.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 namespace Altinn.Platform.Events.Models
 {
     /// <summary>

--- a/src/Models/Events/Subscription.cs
+++ b/src/Models/Events/Subscription.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Text.Json.Serialization;
 using System.Text.Json;
 using System;

--- a/src/Models/Events/SubscriptionRequestModel.cs
+++ b/src/Models/Events/SubscriptionRequestModel.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/Models/FrontendVersion.cs
+++ b/src/Models/FrontendVersion.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using Microsoft.AspNetCore.Mvc.Rendering;
 
 using System.Collections.Generic;

--- a/src/Models/InstanceLock.cs
+++ b/src/Models/InstanceLock.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 namespace Altinn.Platform.Storage.Models;
 
 /// <summary>

--- a/src/Models/LocalFrontendInfo.cs
+++ b/src/Models/LocalFrontendInfo.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 namespace LocalTest.Models;
 
 public struct LocalFrontendInfo

--- a/src/Models/LockToken.cs
+++ b/src/Models/LockToken.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Buffers.Text;
 using System.Diagnostics;
 using System.Text.Json;

--- a/src/Models/PersonLookupIdentifiers.cs
+++ b/src/Models/PersonLookupIdentifiers.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.Text;

--- a/src/Models/ResourceRegistry/CompetentAuthority.cs
+++ b/src/Models/ResourceRegistry/CompetentAuthority.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 namespace Altinn.ResourceRegistry.Core.Models
 {
     /// <summary>

--- a/src/Models/ResourceRegistry/Keyword.cs
+++ b/src/Models/ResourceRegistry/Keyword.cs
@@ -1,4 +1,6 @@
-﻿namespace Altinn.ResourceRegistry.Core.Models
+#nullable disable
+
+namespace Altinn.ResourceRegistry.Core.Models
 {
     /// <summary>
     /// Model for defining keywords

--- a/src/Models/ResourceRegistry/ReferenceSource.cs
+++ b/src/Models/ResourceRegistry/ReferenceSource.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.Serialization;
+#nullable disable
+
+using System.Runtime.Serialization;
 
 namespace Altinn.ResourceRegistry.Core.Enums
 {

--- a/src/Models/ResourceRegistry/ReferenceType.cs
+++ b/src/Models/ResourceRegistry/ReferenceType.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Runtime.Serialization;
 
 namespace Altinn.ResourceRegistry.Core.Enums

--- a/src/Models/ResourceRegistry/ResourceReference.cs
+++ b/src/Models/ResourceRegistry/ResourceReference.cs
@@ -1,4 +1,3 @@
-﻿#nullable enable
 using System.Text.Json.Serialization;
 using Altinn.ResourceRegistry.Core.Enums;
 

--- a/src/Models/ResourceRegistry/ResourceSearch.cs
+++ b/src/Models/ResourceRegistry/ResourceSearch.cs
@@ -1,4 +1,3 @@
-﻿#nullable enable
 using Altinn.ResourceRegistry.Core.Enums;
 
 namespace Altinn.ResourceRegistry.Core.Models

--- a/src/Models/ResourceRegistry/ResourceType.cs
+++ b/src/Models/ResourceRegistry/ResourceType.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 

--- a/src/Models/ResourceRegistry/ServiceResource.cs
+++ b/src/Models/ResourceRegistry/ServiceResource.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using Altinn.ResourceRegistry.Core.Enums;
 using Altinn.ResourceRegistry.Core.Models;
 using System.Text.Json.Serialization;

--- a/src/Models/ServiceError.cs
+++ b/src/Models/ServiceError.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 namespace Altinn.Platform.Storage.Models
 {
     /// <summary>

--- a/src/Models/StartAppModel.cs
+++ b/src/Models/StartAppModel.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using Microsoft.AspNetCore.Mvc.Rendering;
 using System;
 using System.Collections.Generic;

--- a/src/Models/Storage/FileScanRequest.cs
+++ b/src/Models/Storage/FileScanRequest.cs
@@ -1,4 +1,6 @@
-﻿using System;
+#nullable disable
+
+using System;
 
 namespace Altinn.Platform.Storage.Models
 {

--- a/src/Models/Storage/PartyType.cs
+++ b/src/Models/Storage/PartyType.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 namespace Altinn.Platform.Storage.Models;
 
 /// <summary>

--- a/src/Models/Storage/RepositoryException.cs
+++ b/src/Models/Storage/RepositoryException.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Net;
 

--- a/src/Models/TenorViewModel.cs
+++ b/src/Models/TenorViewModel.cs
@@ -1,4 +1,3 @@
-#nullable enable
 namespace LocalTest.Models;
 
 using LocalTest.Services.Tenor.Models;

--- a/src/Models/TokensModel.cs
+++ b/src/Models/TokensModel.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using Microsoft.AspNetCore.Mvc.Rendering;
 
 namespace LocalTest.Models;

--- a/src/Models/UserAuthenticationModel.cs
+++ b/src/Models/UserAuthenticationModel.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Notifications/API/Controllers/EmailNotificationOrdersController.cs
+++ b/src/Notifications/API/Controllers/EmailNotificationOrdersController.cs
@@ -1,4 +1,3 @@
-﻿#nullable enable
 #if !LOCALTEST
 using Altinn.Notifications.Configuration;
 #endif

--- a/src/Notifications/API/Controllers/SmsNotificationOrdersController.cs
+++ b/src/Notifications/API/Controllers/SmsNotificationOrdersController.cs
@@ -1,4 +1,3 @@
-﻿#nullable enable
 #if !LOCALTEST
 using Altinn.Notifications.Configuration;
 #endif

--- a/src/Notifications/API/Extensions/HttpContextExtensions.cs
+++ b/src/Notifications/API/Extensions/HttpContextExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Altinn.Notifications.Extensions;
+#nullable disable
+
+namespace Altinn.Notifications.Extensions;
 
 /// <summary>
 /// Extensions for HTTP Context

--- a/src/Notifications/API/Extensions/ResourceLinkExtensions.cs
+++ b/src/Notifications/API/Extensions/ResourceLinkExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Notifications.Core.Models.Orders;
+#nullable disable
+
+using Altinn.Notifications.Core.Models.Orders;
 using Altinn.Notifications.Models;
 
 namespace Altinn.Notifications.Extensions;

--- a/src/Notifications/API/Mappers/NotificationOrderRequestResponseMapper.cs
+++ b/src/Notifications/API/Mappers/NotificationOrderRequestResponseMapper.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Notifications.Core.Models.Orders;
+#nullable disable
+
+using Altinn.Notifications.Core.Models.Orders;
 using Altinn.Notifications.Models;
 
 namespace Altinn.Notifications.Mappers;

--- a/src/Notifications/API/Mappers/OrderMapper.cs
+++ b/src/Notifications/API/Mappers/OrderMapper.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Notifications.Core.Enums;
+#nullable disable
+
+using Altinn.Notifications.Core.Enums;
 using Altinn.Notifications.Core.Models;
 using Altinn.Notifications.Core.Models.Address;
 using Altinn.Notifications.Core.Models.NotificationTemplate;

--- a/src/Notifications/API/Models/BaseNotificationOrderExt.cs
+++ b/src/Notifications/API/Models/BaseNotificationOrderExt.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+#nullable disable
+
+using System.Text.Json.Serialization;
 
 namespace Altinn.Notifications.Models;
 

--- a/src/Notifications/API/Models/EmailContentTypeExt.cs
+++ b/src/Notifications/API/Models/EmailContentTypeExt.cs
@@ -1,4 +1,6 @@
-﻿namespace Altinn.Notifications.Models;
+#nullable disable
+
+namespace Altinn.Notifications.Models;
 
 /// <summary>
 /// Enum describing available content types for an email.

--- a/src/Notifications/API/Models/EmailNotificationOrderRequestExt.cs
+++ b/src/Notifications/API/Models/EmailNotificationOrderRequestExt.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel.DataAnnotations;
+#nullable disable
+
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 

--- a/src/Notifications/API/Models/EmailNotificationSummaryExt.cs
+++ b/src/Notifications/API/Models/EmailNotificationSummaryExt.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+#nullable disable
+
+using System.Text.Json.Serialization;
 
 namespace Altinn.Notifications.Core.Models.Notification
 {

--- a/src/Notifications/API/Models/EmailNotificationWithResultExt.cs
+++ b/src/Notifications/API/Models/EmailNotificationWithResultExt.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+#nullable disable
+
+using System.Text.Json.Serialization;
 
 using Altinn.Notifications.Models;
 

--- a/src/Notifications/API/Models/EmailTemplateExt.cs
+++ b/src/Notifications/API/Models/EmailTemplateExt.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+#nullable disable
+
+using System.Text.Json.Serialization;
 
 namespace Altinn.Notifications.Models;
 

--- a/src/Notifications/API/Models/IBaseNotificationOrderExt.cs
+++ b/src/Notifications/API/Models/IBaseNotificationOrderExt.cs
@@ -1,4 +1,3 @@
-﻿#nullable enable
 namespace Altinn.Notifications.Models;
 
 /// <summary>

--- a/src/Notifications/API/Models/NotificationChannelExt.cs
+++ b/src/Notifications/API/Models/NotificationChannelExt.cs
@@ -1,4 +1,6 @@
-﻿namespace Altinn.Notifications.Models;
+#nullable disable
+
+namespace Altinn.Notifications.Models;
 
 /// <summary>
 /// Enum describing available notification channels.

--- a/src/Notifications/API/Models/NotificationOrderExt.cs
+++ b/src/Notifications/API/Models/NotificationOrderExt.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+#nullable disable
+
+using System.Text.Json.Serialization;
 
 namespace Altinn.Notifications.Models;
 

--- a/src/Notifications/API/Models/NotificationOrderListExt.cs
+++ b/src/Notifications/API/Models/NotificationOrderListExt.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+#nullable disable
+
+using System.Text.Json.Serialization;
 
 namespace Altinn.Notifications.Models;
 

--- a/src/Notifications/API/Models/NotificationOrderRequestBaseExt.cs
+++ b/src/Notifications/API/Models/NotificationOrderRequestBaseExt.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel.DataAnnotations;
+#nullable disable
+
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
 namespace Altinn.Notifications.Models;

--- a/src/Notifications/API/Models/NotificationOrderRequestResponseExt.cs
+++ b/src/Notifications/API/Models/NotificationOrderRequestResponseExt.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+#nullable disable
+
+using System.Text.Json.Serialization;
 
 namespace Altinn.Notifications.Models;
 

--- a/src/Notifications/API/Models/NotificationOrderWithStatusExt.cs
+++ b/src/Notifications/API/Models/NotificationOrderWithStatusExt.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+#nullable disable
+
+using System.Text.Json.Serialization;
 
 namespace Altinn.Notifications.Models;
 

--- a/src/Notifications/API/Models/NotificationResourceLinksExt.cs
+++ b/src/Notifications/API/Models/NotificationResourceLinksExt.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+#nullable disable
+
+using System.Text.Json.Serialization;
 
 namespace Altinn.Notifications.Models;
 

--- a/src/Notifications/API/Models/NotificationStatusExt.cs
+++ b/src/Notifications/API/Models/NotificationStatusExt.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+#nullable disable
+
+using System.Text.Json.Serialization;
 
 namespace Altinn.Notifications.Models;
 

--- a/src/Notifications/API/Models/NotificationsStatusSummaryExt.cs
+++ b/src/Notifications/API/Models/NotificationsStatusSummaryExt.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+#nullable disable
+
+using System.Text.Json.Serialization;
 
 namespace Altinn.Notifications.Models;
 

--- a/src/Notifications/API/Models/OrderIdExt.cs
+++ b/src/Notifications/API/Models/OrderIdExt.cs
@@ -1,4 +1,3 @@
-﻿#nullable enable
 using System.Text.Json.Serialization;
 
 namespace Altinn.Notifications.Models;

--- a/src/Notifications/API/Models/OrderResourceLinksExt.cs
+++ b/src/Notifications/API/Models/OrderResourceLinksExt.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+#nullable disable
+
+using System.Text.Json.Serialization;
 
 namespace Altinn.Notifications.Models;
 

--- a/src/Notifications/API/Models/RecipientExt.cs
+++ b/src/Notifications/API/Models/RecipientExt.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+#nullable disable
+
+using System.Text.Json.Serialization;
 
 namespace Altinn.Notifications.Models;
 

--- a/src/Notifications/API/Models/RecipientLookupResultExt.cs
+++ b/src/Notifications/API/Models/RecipientLookupResultExt.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+#nullable disable
+
+using System.Text.Json.Serialization;
 
 namespace Altinn.Notifications.Models;
 

--- a/src/Notifications/API/Models/SmsNotificationOrderRequestExt.cs
+++ b/src/Notifications/API/Models/SmsNotificationOrderRequestExt.cs
@@ -1,4 +1,6 @@
-﻿using System.ComponentModel.DataAnnotations;
+#nullable disable
+
+using System.ComponentModel.DataAnnotations;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 

--- a/src/Notifications/API/Models/SmsNotificationSummaryExt.cs
+++ b/src/Notifications/API/Models/SmsNotificationSummaryExt.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+#nullable disable
+
+using System.Text.Json.Serialization;
 
 namespace Altinn.Notifications.Core.Models.Notification
 {

--- a/src/Notifications/API/Models/SmsNotificationWithResultExt.cs
+++ b/src/Notifications/API/Models/SmsNotificationWithResultExt.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+#nullable disable
+
+using System.Text.Json.Serialization;
 
 using Altinn.Notifications.Models;
 

--- a/src/Notifications/API/Models/SmsTemplateExt.cs
+++ b/src/Notifications/API/Models/SmsTemplateExt.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+#nullable disable
+
+using System.Text.Json.Serialization;
 
 namespace Altinn.Notifications.Models
 {

--- a/src/Notifications/API/Models/StatusExt.cs
+++ b/src/Notifications/API/Models/StatusExt.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+#nullable disable
+
+using System.Text.Json.Serialization;
 
 namespace Altinn.Notifications.Models;
 

--- a/src/Notifications/API/Validators/EmailNotificationOrderRequestValidator.cs
+++ b/src/Notifications/API/Validators/EmailNotificationOrderRequestValidator.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.RegularExpressions;
+#nullable disable
+
+using System.Text.RegularExpressions;
 
 using Altinn.Notifications.Models;
 

--- a/src/Notifications/API/Validators/SmsNotificationOrderRequestValidator.cs
+++ b/src/Notifications/API/Validators/SmsNotificationOrderRequestValidator.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Notifications.Core.Helpers;
+#nullable disable
+
+using Altinn.Notifications.Core.Helpers;
 using Altinn.Notifications.Models;
 
 using FluentValidation;

--- a/src/Notifications/API/Validators/ValidationConstants.cs
+++ b/src/Notifications/API/Validators/ValidationConstants.cs
@@ -1,4 +1,6 @@
-﻿namespace Altinn.Notifications.Validators
+#nullable disable
+
+namespace Altinn.Notifications.Validators
 {
     /// <summary>
     /// Class comprised of all shared validation constants

--- a/src/Notifications/API/Validators/ValidationResultExtensions.cs
+++ b/src/Notifications/API/Validators/ValidationResultExtensions.cs
@@ -1,4 +1,6 @@
-﻿using FluentValidation.Results;
+#nullable disable
+
+using FluentValidation.Results;
 
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 

--- a/src/Notifications/Core/Configuration/NotificationOrderConfig.cs
+++ b/src/Notifications/Core/Configuration/NotificationOrderConfig.cs
@@ -1,4 +1,6 @@
-﻿namespace Altinn.Notifications.Core.Configuration;
+#nullable disable
+
+namespace Altinn.Notifications.Core.Configuration;
 
 /// <summary>
 /// Configuration class for notification orders

--- a/src/Notifications/Core/Enums/AddressType.cs
+++ b/src/Notifications/Core/Enums/AddressType.cs
@@ -1,4 +1,6 @@
-﻿namespace Altinn.Notifications.Core.Enums;
+#nullable disable
+
+namespace Altinn.Notifications.Core.Enums;
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 /// <summary>

--- a/src/Notifications/Core/Enums/AltinnServiceUpdateSchema.cs
+++ b/src/Notifications/Core/Enums/AltinnServiceUpdateSchema.cs
@@ -1,4 +1,6 @@
-﻿namespace Altinn.Notifications.Core.Enums;
+#nullable disable
+
+namespace Altinn.Notifications.Core.Enums;
 
 /// <summary>
 /// Enum describing the various Altinn Service update schemas 

--- a/src/Notifications/Core/Enums/EmailContentType.cs
+++ b/src/Notifications/Core/Enums/EmailContentType.cs
@@ -1,4 +1,6 @@
-﻿namespace Altinn.Notifications.Core.Enums;
+#nullable disable
+
+namespace Altinn.Notifications.Core.Enums;
 
 /// <summary>
 /// Enum describing available email content types

--- a/src/Notifications/Core/Enums/EmailNotificationResultType.cs
+++ b/src/Notifications/Core/Enums/EmailNotificationResultType.cs
@@ -1,4 +1,6 @@
-﻿namespace Altinn.Notifications.Core.Enums;
+#nullable disable
+
+namespace Altinn.Notifications.Core.Enums;
 
 /// <summary>
 /// Enum describing email notification result types

--- a/src/Notifications/Core/Enums/IResultType.cs
+++ b/src/Notifications/Core/Enums/IResultType.cs
@@ -1,4 +1,6 @@
-﻿namespace Altinn.Notifications.Core.Enums;
+#nullable disable
+
+namespace Altinn.Notifications.Core.Enums;
 
 /// <summary>
 /// Base class for send result of a notification

--- a/src/Notifications/Core/Enums/NotificationChannel.cs
+++ b/src/Notifications/Core/Enums/NotificationChannel.cs
@@ -1,4 +1,6 @@
-﻿namespace Altinn.Notifications.Core.Enums;
+#nullable disable
+
+namespace Altinn.Notifications.Core.Enums;
 
 /// <summary>
 /// Enum describing available notification channels.

--- a/src/Notifications/Core/Enums/NotificationTemplateType.cs
+++ b/src/Notifications/Core/Enums/NotificationTemplateType.cs
@@ -1,4 +1,6 @@
-﻿namespace Altinn.Notifications.Core.Enums;
+#nullable disable
+
+namespace Altinn.Notifications.Core.Enums;
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 /// <summary>

--- a/src/Notifications/Core/Enums/OrderProcessingStatus.cs
+++ b/src/Notifications/Core/Enums/OrderProcessingStatus.cs
@@ -1,4 +1,6 @@
-﻿namespace Altinn.Notifications.Core.Enums;
+#nullable disable
+
+namespace Altinn.Notifications.Core.Enums;
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
 /// <summary>

--- a/src/Notifications/Core/Enums/SmsNotificationResultType.cs
+++ b/src/Notifications/Core/Enums/SmsNotificationResultType.cs
@@ -1,4 +1,6 @@
-﻿namespace Altinn.Notifications.Core.Enums;
+#nullable disable
+
+namespace Altinn.Notifications.Core.Enums;
 
 /// <summary>
 /// Enum describing sms notification result types

--- a/src/Notifications/Core/Helpers/MobileNumberHelper.cs
+++ b/src/Notifications/Core/Helpers/MobileNumberHelper.cs
@@ -1,4 +1,6 @@
-﻿using PhoneNumbers;
+#nullable disable
+
+using PhoneNumbers;
 
 namespace Altinn.Notifications.Core.Helpers
 {

--- a/src/Notifications/Core/Integrations/IAuthorizationService.cs
+++ b/src/Notifications/Core/Integrations/IAuthorizationService.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Notifications.Core.Models.ContactPoints;
+#nullable disable
+
+using Altinn.Notifications.Core.Models.ContactPoints;
 
 namespace Altinn.Notifications.Core.Integrations;
 

--- a/src/Notifications/Core/Integrations/IProfileClient.cs
+++ b/src/Notifications/Core/Integrations/IProfileClient.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Notifications.Core.Models.ContactPoints;
+#nullable disable
+
+using Altinn.Notifications.Core.Models.ContactPoints;
 
 namespace Altinn.Notifications.Core.Integrations;
 

--- a/src/Notifications/Core/Integrations/IRegisterClient.cs
+++ b/src/Notifications/Core/Integrations/IRegisterClient.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Notifications.Core.Models.ContactPoints;
+#nullable disable
+
+using Altinn.Notifications.Core.Models.ContactPoints;
 
 namespace Altinn.Notifications.Core.Integrations
 {

--- a/src/Notifications/Core/JsonSerializerOptionsProvider.cs
+++ b/src/Notifications/Core/JsonSerializerOptionsProvider.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json;
+#nullable disable
+
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Altinn.Notifications.Core

--- a/src/Notifications/Core/Models/Address/EmailAddressPoint.cs
+++ b/src/Notifications/Core/Models/Address/EmailAddressPoint.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Notifications.Core.Enums;
+#nullable disable
+
+using Altinn.Notifications.Core.Enums;
 
 namespace Altinn.Notifications.Core.Models.Address;
 

--- a/src/Notifications/Core/Models/Address/IAddressPoint.cs
+++ b/src/Notifications/Core/Models/Address/IAddressPoint.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+#nullable disable
+
+using System.Text.Json.Serialization;
 
 using Altinn.Notifications.Core.Enums;
 

--- a/src/Notifications/Core/Models/Address/SmsAddressPoint.cs
+++ b/src/Notifications/Core/Models/Address/SmsAddressPoint.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Notifications.Core.Enums;
+#nullable disable
+
+using Altinn.Notifications.Core.Enums;
 
 namespace Altinn.Notifications.Core.Models.Address;
 

--- a/src/Notifications/Core/Models/AltinnServiceUpdate/GenericServiceUpdate.cs
+++ b/src/Notifications/Core/Models/AltinnServiceUpdate/GenericServiceUpdate.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json;
+#nullable disable
+
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 using Altinn.Notifications.Core.Enums;

--- a/src/Notifications/Core/Models/AltinnServiceUpdate/ResourceLimitExceeded.cs
+++ b/src/Notifications/Core/Models/AltinnServiceUpdate/ResourceLimitExceeded.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json;
+#nullable disable
+
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace Altinn.Notifications.Core.Models.AltinnServiceUpdate

--- a/src/Notifications/Core/Models/ContactPoints/OrganizationContactPoints.cs
+++ b/src/Notifications/Core/Models/ContactPoints/OrganizationContactPoints.cs
@@ -1,4 +1,6 @@
-﻿using System.Linq;
+#nullable disable
+
+using System.Linq;
 
 namespace Altinn.Notifications.Core.Models.ContactPoints;
 

--- a/src/Notifications/Core/Models/ContactPoints/UserContactPoints.cs
+++ b/src/Notifications/Core/Models/ContactPoints/UserContactPoints.cs
@@ -1,4 +1,6 @@
-﻿namespace Altinn.Notifications.Core.Models.ContactPoints;
+#nullable disable
+
+namespace Altinn.Notifications.Core.Models.ContactPoints;
 
 /// <summary>
 /// Class describing the availability of contact points for a user

--- a/src/Notifications/Core/Models/Creator.cs
+++ b/src/Notifications/Core/Models/Creator.cs
@@ -1,4 +1,6 @@
-﻿namespace Altinn.Notifications.Core.Models;
+#nullable disable
+
+namespace Altinn.Notifications.Core.Models;
 
 /// <summary>
 /// A class representing a notification creator 

--- a/src/Notifications/Core/Models/Email.cs
+++ b/src/Notifications/Core/Models/Email.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json;
+#nullable disable
+
+using System.Text.Json;
 
 using Altinn.Notifications.Core.Enums;
 

--- a/src/Notifications/Core/Models/NotificationTemplate/EmailTemplate.cs
+++ b/src/Notifications/Core/Models/NotificationTemplate/EmailTemplate.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Notifications.Core.Enums;
+#nullable disable
+
+using Altinn.Notifications.Core.Enums;
 
 namespace Altinn.Notifications.Core.Models.NotificationTemplate;
 

--- a/src/Notifications/Core/Models/NotificationTemplate/INotificationTemplate.cs
+++ b/src/Notifications/Core/Models/NotificationTemplate/INotificationTemplate.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+#nullable disable
+
+using System.Text.Json.Serialization;
 
 using Altinn.Notifications.Core.Enums;
 

--- a/src/Notifications/Core/Models/NotificationTemplate/SmsTemplate.cs
+++ b/src/Notifications/Core/Models/NotificationTemplate/SmsTemplate.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using Altinn.Notifications.Core.Enums;
 
 namespace Altinn.Notifications.Core.Models.NotificationTemplate;

--- a/src/Notifications/Core/Models/Orders/IBaseNotificationOrder.cs
+++ b/src/Notifications/Core/Models/Orders/IBaseNotificationOrder.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Notifications.Core.Enums;
+#nullable disable
+
+using Altinn.Notifications.Core.Enums;
 
 namespace Altinn.Notifications.Core.Models.Orders;
 

--- a/src/Notifications/Core/Models/Orders/NotificationOrder.cs
+++ b/src/Notifications/Core/Models/Orders/NotificationOrder.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json;
+#nullable disable
+
+using System.Text.Json;
 
 using Altinn.Notifications.Core.Enums;
 using Altinn.Notifications.Core.Models.NotificationTemplate;

--- a/src/Notifications/Core/Models/Orders/NotificationOrderRequest.cs
+++ b/src/Notifications/Core/Models/Orders/NotificationOrderRequest.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Notifications.Core.Enums;
+#nullable disable
+
+using Altinn.Notifications.Core.Enums;
 using Altinn.Notifications.Core.Models.NotificationTemplate;
 
 namespace Altinn.Notifications.Core.Models.Orders;

--- a/src/Notifications/Core/Models/Orders/NotificationOrderRequestResponse.cs
+++ b/src/Notifications/Core/Models/Orders/NotificationOrderRequestResponse.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+#nullable disable
+
+using System.Text.Json.Serialization;
 
 namespace Altinn.Notifications.Core.Models.Orders;
 

--- a/src/Notifications/Core/Models/Orders/NotificationOrderWithStatus.cs
+++ b/src/Notifications/Core/Models/Orders/NotificationOrderWithStatus.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json.Serialization;
+#nullable disable
+
+using System.Text.Json.Serialization;
 
 using Altinn.Notifications.Core.Enums;
 

--- a/src/Notifications/Core/Models/Recipient.cs
+++ b/src/Notifications/Core/Models/Recipient.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json;
+#nullable disable
+
+using System.Text.Json;
 
 using Altinn.Notifications.Core.Models.Address;
 

--- a/src/Notifications/Core/Models/Recipients/EmailRecipient.cs
+++ b/src/Notifications/Core/Models/Recipients/EmailRecipient.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 namespace Altinn.Notifications.Core.Models.Recipients;
 
 /// <summary>

--- a/src/Notifications/Core/Models/Recipients/SmsRecipient.cs
+++ b/src/Notifications/Core/Models/Recipients/SmsRecipient.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 namespace Altinn.Notifications.Core.Models.Recipients;
 
 /// <summary>

--- a/src/Notifications/Core/Models/Sms.cs
+++ b/src/Notifications/Core/Models/Sms.cs
@@ -1,4 +1,6 @@
-﻿using System.Text.Json;
+#nullable disable
+
+using System.Text.Json;
 
 namespace Altinn.Notifications.Core.Models;
 

--- a/src/Notifications/Core/Persistence/IOrderRepository.cs
+++ b/src/Notifications/Core/Persistence/IOrderRepository.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Notifications.Core.Enums;
+#nullable disable
+
+using Altinn.Notifications.Core.Enums;
 using Altinn.Notifications.Core.Models.Orders;
 
 namespace Altinn.Notifications.Core.Persistence;

--- a/src/Notifications/Core/Services/ContactPointService.cs
+++ b/src/Notifications/Core/Services/ContactPointService.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Notifications.Core.Helpers;
+#nullable disable
+
+using Altinn.Notifications.Core.Helpers;
 using Altinn.Notifications.Core.Integrations;
 using Altinn.Notifications.Core.Models;
 using Altinn.Notifications.Core.Models.Address;

--- a/src/Notifications/Core/Services/DateTimeService.cs
+++ b/src/Notifications/Core/Services/DateTimeService.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
+#nullable disable
+
+using System.Diagnostics.CodeAnalysis;
 
 using Altinn.Notifications.Core.Services.Interfaces;
 

--- a/src/Notifications/Core/Services/GuidService.cs
+++ b/src/Notifications/Core/Services/GuidService.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
+#nullable disable
+
+using System.Diagnostics.CodeAnalysis;
 
 using Altinn.Notifications.Core.Services.Interfaces;
 

--- a/src/Notifications/Core/Services/Interfaces/IContactPointService.cs
+++ b/src/Notifications/Core/Services/Interfaces/IContactPointService.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Notifications.Core.Models;
+#nullable disable
+
+using Altinn.Notifications.Core.Models;
 
 namespace Altinn.Notifications.Core.Services.Interfaces
 {

--- a/src/Notifications/Core/Services/Interfaces/IDateTimeService.cs
+++ b/src/Notifications/Core/Services/Interfaces/IDateTimeService.cs
@@ -1,4 +1,6 @@
-﻿namespace Altinn.Notifications.Core.Services.Interfaces;
+#nullable disable
+
+namespace Altinn.Notifications.Core.Services.Interfaces;
 
 /// <summary>
 /// Interface describing a dateTime service

--- a/src/Notifications/Core/Services/Interfaces/IGuidService.cs
+++ b/src/Notifications/Core/Services/Interfaces/IGuidService.cs
@@ -1,4 +1,6 @@
-﻿namespace Altinn.Notifications.Core.Services.Interfaces;
+#nullable disable
+
+namespace Altinn.Notifications.Core.Services.Interfaces;
 
 /// <summary>
 /// Interface describing a guid service

--- a/src/Notifications/Core/Services/Interfaces/IOrderRequestService.cs
+++ b/src/Notifications/Core/Services/Interfaces/IOrderRequestService.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Notifications.Core.Models.Orders;
+#nullable disable
+
+using Altinn.Notifications.Core.Models.Orders;
 
 namespace Altinn.Notifications.Core.Services.Interfaces;
 

--- a/src/Notifications/Core/Services/OrderRequestService.cs
+++ b/src/Notifications/Core/Services/OrderRequestService.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Notifications.Core.Configuration;
+#nullable disable
+
+using Altinn.Notifications.Core.Configuration;
 using Altinn.Notifications.Core.Enums;
 using Altinn.Notifications.Core.Models;
 using Altinn.Notifications.Core.Models.NotificationTemplate;

--- a/src/Notifications/Core/Shared/Result.cs
+++ b/src/Notifications/Core/Shared/Result.cs
@@ -1,4 +1,3 @@
-﻿#nullable enable
 namespace Altinn.Notifications.Core.Shared;
 
 /// <summary>

--- a/src/Notifications/Core/Shared/ServiceError.cs
+++ b/src/Notifications/Core/Shared/ServiceError.cs
@@ -1,4 +1,3 @@
-﻿#nullable enable
 namespace Altinn.Notifications.Core.Shared;
 
 /// <summary>

--- a/src/Notifications/LocalTestNotifications/LocalAuthorizationService.cs
+++ b/src/Notifications/LocalTestNotifications/LocalAuthorizationService.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Notifications.Core.Integrations;
+#nullable disable
+
+using Altinn.Notifications.Core.Integrations;
 using Altinn.Notifications.Core.Models.ContactPoints;
 
 namespace LocalTest.Notifications.LocalTestNotifications

--- a/src/Notifications/LocalTestNotifications/LocalOrderRepository.cs
+++ b/src/Notifications/LocalTestNotifications/LocalOrderRepository.cs
@@ -1,4 +1,3 @@
-﻿#nullable enable
 using System.Text.Json;
 
 using Altinn.Notifications.Core.Enums;

--- a/src/Notifications/LocalTestNotifications/LocalProfileClient.cs
+++ b/src/Notifications/LocalTestNotifications/LocalProfileClient.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Notifications.Core.Integrations;
+#nullable disable
+
+using Altinn.Notifications.Core.Integrations;
 using Altinn.Notifications.Core.Models.ContactPoints;
 
 using LocalTest.Services.TestData;

--- a/src/Notifications/LocalTestNotifications/LocalRegisterClient.cs
+++ b/src/Notifications/LocalTestNotifications/LocalRegisterClient.cs
@@ -1,4 +1,6 @@
-﻿using Altinn.Notifications.Core.Integrations;
+#nullable disable
+
+using Altinn.Notifications.Core.Integrations;
 using Altinn.Notifications.Core.Models.ContactPoints;
 
 using LocalTest.Services.TestData;

--- a/src/Notifications/LocalTestNotifications/NotificationsServiceExtentions.cs
+++ b/src/Notifications/LocalTestNotifications/NotificationsServiceExtentions.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using Altinn.Notifications.Core.Configuration;
 using Altinn.Notifications.Core.Integrations;
 using Altinn.Notifications.Core.Persistence;

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 

--- a/src/Services/AccessManagement/LocalInstanceDelegationsRepository.cs
+++ b/src/Services/AccessManagement/LocalInstanceDelegationsRepository.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Buffers.Text;
 using System.Text;
 using System.Text.Json;

--- a/src/Services/Authentication/Implementation/AuthenticationService.cs
+++ b/src/Services/Authentication/Implementation/AuthenticationService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Security.Cryptography.X509Certificates;

--- a/src/Services/Authentication/Implementation/TestAuthenticationService.cs
+++ b/src/Services/Authentication/Implementation/TestAuthenticationService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Text.Json;

--- a/src/Services/Authentication/Interface/IAuthentication.cs
+++ b/src/Services/Authentication/Interface/IAuthentication.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Security.Claims;
 using System.Threading.Tasks;
 using System.IdentityModel.Tokens.Jwt;

--- a/src/Services/Authorization/Constants/AltinnXacmlConstants.cs
+++ b/src/Services/Authorization/Constants/AltinnXacmlConstants.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 namespace Altinn.Platform.Authorization.Constants
 {
     /// <summary>

--- a/src/Services/Authorization/Implementation/ClaimsService.cs
+++ b/src/Services/Authorization/Implementation/ClaimsService.cs
@@ -1,4 +1,3 @@
-﻿#nullable enable
 using System.Security.Claims;
 using Altinn.Platform.Authorization.Services.Interface;
 using LocalTest.Services.TestData;

--- a/src/Services/Authorization/Implementation/ContextHandler.cs
+++ b/src/Services/Authorization/Implementation/ContextHandler.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Services/Authorization/Implementation/PartiesService.cs
+++ b/src/Services/Authorization/Implementation/PartiesService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using Altinn.Platform.Authorization.Services.Interface;
 using Altinn.Platform.Register.Models;
 using LocalTest.Services.TestData;

--- a/src/Services/Authorization/Implementation/PolicyInformationRepository.cs
+++ b/src/Services/Authorization/Implementation/PolicyInformationRepository.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Threading.Tasks;
 

--- a/src/Services/Authorization/Implementation/PolicyRetrievalPoint.cs
+++ b/src/Services/Authorization/Implementation/PolicyRetrievalPoint.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.IO;
 using System.Linq;

--- a/src/Services/Authorization/Implementation/RolesWrapper.cs
+++ b/src/Services/Authorization/Implementation/RolesWrapper.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using Altinn.Platform.Authorization.Services.Interface;
 using Authorization.Interface.Models;
 using LocalTest.Services.TestData;

--- a/src/Services/Authorization/Interface/IClaims.cs
+++ b/src/Services/Authorization/Interface/IClaims.cs
@@ -1,4 +1,3 @@
-﻿#nullable enable
 using System.Security.Claims;
 
 namespace Altinn.Platform.Authorization.Services.Interface

--- a/src/Services/Authorization/Interface/IParties.cs
+++ b/src/Services/Authorization/Interface/IParties.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using Altinn.Platform.Register.Models;
 
 namespace Altinn.Platform.Authorization.Services.Interface

--- a/src/Services/Authorization/Interface/IPolicyInformationRepository.cs
+++ b/src/Services/Authorization/Interface/IPolicyInformationRepository.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Threading.Tasks;
 using Altinn.Platform.Storage.Interface.Models;
 

--- a/src/Services/Authorization/Interface/IPolicyRetrievalPoint.cs
+++ b/src/Services/Authorization/Interface/IPolicyRetrievalPoint.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using Altinn.Authorization.ABAC.Xacml;
 using System.IO;
 using System.Threading.Tasks;

--- a/src/Services/Authorization/Interface/IRoles.cs
+++ b/src/Services/Authorization/Interface/IRoles.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Services/Events/Implementation/EventsRepository.cs
+++ b/src/Services/Events/Implementation/EventsRepository.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.IO;
 using System.Threading.Tasks;

--- a/src/Services/Events/Implementation/SubscriptionService.cs
+++ b/src/Services/Events/Implementation/SubscriptionService.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/Services/Events/Interface/IEventsRepository.cs
+++ b/src/Services/Events/Interface/IEventsRepository.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Threading.Tasks;
 using Altinn.Platform.Events.Models;
 

--- a/src/Services/Events/Interface/ISubscriptionService.cs
+++ b/src/Services/Events/Interface/ISubscriptionService.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Altinn.Platform.Events.Models;

--- a/src/Services/Events/Mappers/SubscriptionMapper.cs
+++ b/src/Services/Events/Mappers/SubscriptionMapper.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using Altinn.Platform.Events.Models;
 
 namespace Altinn.Platform.Events.Mappers

--- a/src/Services/LocalApp/Implementation/LocalAppFile.cs
+++ b/src/Services/LocalApp/Implementation/LocalAppFile.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Net;
 using System.Net.Http;
 using System.Text;

--- a/src/Services/LocalApp/Implementation/LocalAppHttp.cs
+++ b/src/Services/LocalApp/Implementation/LocalAppHttp.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Options;

--- a/src/Services/LocalApp/Interface/ILocalApp.cs
+++ b/src/Services/LocalApp/Interface/ILocalApp.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using Altinn.Platform.Storage.Interface.Models;
 using LocalTest.Services.TestData;
 

--- a/src/Services/LocalFrontend/Implementation/LocalFrontendService.cs
+++ b/src/Services/LocalFrontend/Implementation/LocalFrontendService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using LocalTest.Configuration;
 using LocalTest.Models;
 using LocalTest.Services.LocalFrontend.Interface;

--- a/src/Services/LocalFrontend/Interface/ILocalFrontendService.cs
+++ b/src/Services/LocalFrontend/Interface/ILocalFrontendService.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using LocalTest.Models;
 
 namespace LocalTest.Services.LocalFrontend.Interface;

--- a/src/Services/Profile/Implementation/UserProfilesWrapper.cs
+++ b/src/Services/Profile/Implementation/UserProfilesWrapper.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using Altinn.Platform.Profile.Models;
 using LocalTest.Services.Profile.Interface;
 using LocalTest.Services.TestData;

--- a/src/Services/Profile/Interface/IUserProfiles.cs
+++ b/src/Services/Profile/Interface/IUserProfiles.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using Altinn.Platform.Profile.Models;
 
 namespace LocalTest.Services.Profile.Interface

--- a/src/Services/Register/Implementation/OrganizationsWrapper.cs
+++ b/src/Services/Register/Implementation/OrganizationsWrapper.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using Altinn.Platform.Register.Models;
 using LocalTest.Clients.CdnAltinnOrgs;
 using LocalTest.Services.Register.Interface;

--- a/src/Services/Register/Implementation/PartiesWrapper.cs
+++ b/src/Services/Register/Implementation/PartiesWrapper.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using Altinn.Platform.Register.Enums;
 using Altinn.Platform.Register.Models;
 

--- a/src/Services/Register/Implementation/PersonLookupService.cs
+++ b/src/Services/Register/Implementation/PersonLookupService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Threading.Tasks;
 

--- a/src/Services/Register/Implementation/PersonLookupSettings.cs
+++ b/src/Services/Register/Implementation/PersonLookupSettings.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 namespace Altinn.Platform.Register.Core
 {
     /// <summary>

--- a/src/Services/Register/Implementation/PersonsWrapper.cs
+++ b/src/Services/Register/Implementation/PersonsWrapper.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using Altinn.Platform.Register.Models;
 using LocalTest.Services.Register.Interface;
 using LocalTest.Services.TestData;

--- a/src/Services/Register/Implementation/StringExtensions.cs
+++ b/src/Services/Register/Implementation/StringExtensions.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Globalization;
 using System.Text;

--- a/src/Services/Register/Implementation/TooManyFailedLookupsException.cs
+++ b/src/Services/Register/Implementation/TooManyFailedLookupsException.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 namespace Altinn.Platform.Register.Core
 {
     /// <summary>

--- a/src/Services/Register/Interface/IOrganizations.cs
+++ b/src/Services/Register/Interface/IOrganizations.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using Altinn.Platform.Register.Models;
 
 namespace LocalTest.Services.Register.Interface

--- a/src/Services/Register/Interface/IParties.cs
+++ b/src/Services/Register/Interface/IParties.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using Altinn.Platform.Register.Models;
 
 namespace LocalTest.Services.Register.Interface

--- a/src/Services/Register/Interface/IPersonLookup.cs
+++ b/src/Services/Register/Interface/IPersonLookup.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Threading.Tasks;
 
 using Altinn.Platform.Register.Models;

--- a/src/Services/Register/Interface/IPersons.cs
+++ b/src/Services/Register/Interface/IPersons.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using Altinn.Platform.Register.Models;
 
 namespace LocalTest.Services.Register.Interface

--- a/src/Services/ResourceRegistry/IPolicyRepository.cs
+++ b/src/Services/ResourceRegistry/IPolicyRepository.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.IO;
 using System.Threading.Tasks;

--- a/src/Services/ResourceRegistry/IResourceRegistry.cs
+++ b/src/Services/ResourceRegistry/IResourceRegistry.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Services/ResourceRegistry/IResourceRegistryRepository.cs
+++ b/src/Services/ResourceRegistry/IResourceRegistryRepository.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using Altinn.ResourceRegistry.Core.Models;
 using Altinn.ResourceRegistry.Models;
 using System.Collections.Generic;

--- a/src/Services/ResourceRegistry/PolicyRepositoryMock.cs
+++ b/src/Services/ResourceRegistry/PolicyRepositoryMock.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using Altinn.ResourceRegistry.Core;
 using System;
 using System.IO;

--- a/src/Services/ResourceRegistry/RegisterResourceRepositoryMock.cs
+++ b/src/Services/ResourceRegistry/RegisterResourceRepositoryMock.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using Altinn.ResourceRegistry.Core;
 using Altinn.ResourceRegistry.Core.Models;
 using Altinn.ResourceRegistry.Models;

--- a/src/Services/ResourceRegistry/ResourceRegistryService.cs
+++ b/src/Services/ResourceRegistry/ResourceRegistryService.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Services/Storage/Implementation/ApplicationRepository.cs
+++ b/src/Services/Storage/Implementation/ApplicationRepository.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Services/Storage/Implementation/ApplicationService.cs
+++ b/src/Services/Storage/Implementation/ApplicationService.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Platform.Storage.Models;
 using Altinn.Platform.Storage.Repository;

--- a/src/Services/Storage/Implementation/AsyncLock.cs
+++ b/src/Services/Storage/Implementation/AsyncLock.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 namespace LocalTest.Services.Storage.Implementation;
 
 internal sealed class PartitionedAsyncLock : IDisposable

--- a/src/Services/Storage/Implementation/AuthorizationService.cs
+++ b/src/Services/Storage/Implementation/AuthorizationService.cs
@@ -1,4 +1,6 @@
-﻿﻿using System;
+#nullable disable
+
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;

--- a/src/Services/Storage/Implementation/BlobRepository.cs
+++ b/src/Services/Storage/Implementation/BlobRepository.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using Altinn.Platform.Storage.Interface.Models;
 using LocalTest.Configuration;
 using LocalTest.Services.Storage.Implementation;

--- a/src/Services/Storage/Implementation/ClaimsPrincipalProvider.cs
+++ b/src/Services/Storage/Implementation/ClaimsPrincipalProvider.cs
@@ -1,4 +1,6 @@
-﻿using System.Diagnostics.CodeAnalysis;
+#nullable disable
+
+using System.Diagnostics.CodeAnalysis;
 using System.Security.Claims;
 
 using Microsoft.AspNetCore.Http;

--- a/src/Services/Storage/Implementation/DataRepository.cs
+++ b/src/Services/Storage/Implementation/DataRepository.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;

--- a/src/Services/Storage/Implementation/DataService.cs
+++ b/src/Services/Storage/Implementation/DataService.cs
@@ -1,4 +1,6 @@
-﻿using System;
+#nullable disable
+
+using System;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text.Json;

--- a/src/Services/Storage/Implementation/InstanceAndEventsRepository.cs
+++ b/src/Services/Storage/Implementation/InstanceAndEventsRepository.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Data;
 using Altinn.Platform.Storage.Interface.Models;
 

--- a/src/Services/Storage/Implementation/InstanceEventRepository.cs
+++ b/src/Services/Storage/Implementation/InstanceEventRepository.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Platform.Storage.Repository;
 using LocalTest.Configuration;

--- a/src/Services/Storage/Implementation/InstanceEventService.cs
+++ b/src/Services/Storage/Implementation/InstanceEventService.cs
@@ -1,4 +1,6 @@
-﻿using System;
+#nullable disable
+
+using System;
 using System.Threading.Tasks;
 
 using Altinn.Platform.Storage.Helpers;

--- a/src/Services/Storage/Implementation/InstanceLockRepository.cs
+++ b/src/Services/Storage/Implementation/InstanceLockRepository.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Security.Cryptography;
 using System.Text.Json;
 using Altinn.Platform.Storage.Models;

--- a/src/Services/Storage/Implementation/InstanceQueryParameters.cs
+++ b/src/Services/Storage/Implementation/InstanceQueryParameters.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;

--- a/src/Services/Storage/Implementation/InstanceQueryResponse.cs
+++ b/src/Services/Storage/Implementation/InstanceQueryResponse.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Collections.Generic;
 using Altinn.Platform.Storage.Interface.Models;
 using Newtonsoft.Json;

--- a/src/Services/Storage/Implementation/InstanceRepository.cs
+++ b/src/Services/Storage/Implementation/InstanceRepository.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using Altinn.Platform.Storage.Helpers;
 using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Platform.Storage.Repository;

--- a/src/Services/Storage/Implementation/ProcessAuthorizer.cs
+++ b/src/Services/Storage/Implementation/ProcessAuthorizer.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/Services/Storage/Implementation/ProcessDataCleanupService.cs
+++ b/src/Services/Storage/Implementation/ProcessDataCleanupService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/src/Services/Storage/Implementation/RegisterService.cs
+++ b/src/Services/Storage/Implementation/RegisterService.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Threading.Tasks;
 using Altinn.Platform.Register.Models;
 using LocalTest.Services.Register.Interface;

--- a/src/Services/Storage/Implementation/SigningService.cs
+++ b/src/Services/Storage/Implementation/SigningService.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Text.Json;
 using Altinn.Platform.Storage.Helpers;
 using Altinn.Platform.Storage.Interface.Enums;

--- a/src/Services/Storage/Implementation/StorageAccessHandler.cs
+++ b/src/Services/Storage/Implementation/StorageAccessHandler.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Text;
 using System.Threading.Tasks;

--- a/src/Services/Storage/Implementation/TextRepository.cs
+++ b/src/Services/Storage/Implementation/TextRepository.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Services/Storage/InstanceLockResult.cs
+++ b/src/Services/Storage/InstanceLockResult.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 namespace Altinn.Platform.Storage.Repository;
 
 /// <summary>

--- a/src/Services/Storage/Interface/IApplicationRepository.cs
+++ b/src/Services/Storage/Interface/IApplicationRepository.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using Altinn.Platform.Storage.Interface.Models;
 
 namespace Altinn.Platform.Storage.Repository;

--- a/src/Services/Storage/Interface/IApplicationService.cs
+++ b/src/Services/Storage/Interface/IApplicationService.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Threading.Tasks;
 using Altinn.Platform.Storage.Interface.Models;
 using Altinn.Platform.Storage.Models;

--- a/src/Services/Storage/Interface/IAuthorization.cs
+++ b/src/Services/Storage/Interface/IAuthorization.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+#nullable disable
+
+using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading.Tasks;
 using Altinn.Authorization.ABAC.Xacml.JsonProfile;

--- a/src/Services/Storage/Interface/IBlobRepository.cs
+++ b/src/Services/Storage/Interface/IBlobRepository.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.IO;
 using System.Threading;

--- a/src/Services/Storage/Interface/IClaimsPrincipalProvider.cs
+++ b/src/Services/Storage/Interface/IClaimsPrincipalProvider.cs
@@ -1,4 +1,6 @@
-﻿using System.Security.Claims;
+#nullable disable
+
+using System.Security.Claims;
 
 namespace Altinn.Platform.Storage.Authorization;
 

--- a/src/Services/Storage/Interface/IDataRepository.cs
+++ b/src/Services/Storage/Interface/IDataRepository.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.IO;

--- a/src/Services/Storage/Interface/IDataService.cs
+++ b/src/Services/Storage/Interface/IDataService.cs
@@ -1,4 +1,6 @@
-﻿using System;
+#nullable disable
+
+using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Services/Storage/Interface/IInstanceAndEventsRepository.cs
+++ b/src/Services/Storage/Interface/IInstanceAndEventsRepository.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Services/Storage/Interface/IInstanceEventRepository.cs
+++ b/src/Services/Storage/Interface/IInstanceEventRepository.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;

--- a/src/Services/Storage/Interface/IInstanceEventService.cs
+++ b/src/Services/Storage/Interface/IInstanceEventService.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+#nullable disable
+
+using System.Threading.Tasks;
 using Altinn.Platform.Storage.Interface.Enums;
 using Altinn.Platform.Storage.Interface.Models;
 

--- a/src/Services/Storage/Interface/IInstanceLockRepository.cs
+++ b/src/Services/Storage/Interface/IInstanceLockRepository.cs
@@ -1,5 +1,3 @@
-#nullable enable
-
 using Altinn.Platform.Storage.Models;
 
 namespace Altinn.Platform.Storage.Repository;

--- a/src/Services/Storage/Interface/IInstanceRepository.cs
+++ b/src/Services/Storage/Interface/IInstanceRepository.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/src/Services/Storage/Interface/IProcessAuthorizer.cs
+++ b/src/Services/Storage/Interface/IProcessAuthorizer.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Threading.Tasks;
 using Altinn.Platform.Storage.Interface.Models;
 

--- a/src/Services/Storage/Interface/IProcessDataCleanupService.cs
+++ b/src/Services/Storage/Interface/IProcessDataCleanupService.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Services/Storage/Interface/IRegisterService.cs
+++ b/src/Services/Storage/Interface/IRegisterService.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Threading.Tasks;
 using Altinn.Platform.Register.Models;
 

--- a/src/Services/Storage/Interface/ISigningService.cs
+++ b/src/Services/Storage/Interface/ISigningService.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Services/Storage/Interface/ITextRepository.cs
+++ b/src/Services/Storage/Interface/ITextRepository.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Altinn.Platform.Storage.Interface.Models;

--- a/src/Services/Tenor/TenorDataReader.cs
+++ b/src/Services/Tenor/TenorDataReader.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Text.Json;
 using Authorization.Interface.Models;
 using LocalTest.Configuration;

--- a/src/Services/TestData/AppTestDataModel.cs
+++ b/src/Services/TestData/AppTestDataModel.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Text.Json.Serialization;
 using Altinn.Platform.Authentication.Model;
 using Altinn.Platform.Profile.Models;

--- a/src/Services/TestData/TestDataDiskReader.cs
+++ b/src/Services/TestData/TestDataDiskReader.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Authorization.Interface.Models;

--- a/src/Services/TestData/TestDataModel.cs
+++ b/src/Services/TestData/TestDataModel.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using Altinn.Platform.Authentication.Model;
 using Altinn.Platform.Profile.Models;
 using Altinn.Platform.Register.Models;

--- a/src/Services/TestData/TestDataService.cs
+++ b/src/Services/TestData/TestDataService.cs
@@ -1,4 +1,3 @@
-#nullable enable
 using LocalTest.Configuration;
 using LocalTest.Services.LocalApp.Interface;
 using Microsoft.Extensions.Caching.Memory;

--- a/src/Startup.cs
+++ b/src/Startup.cs
@@ -1,3 +1,5 @@
+#nullable disable
+
 using System.Security.Cryptography.X509Certificates;
 using System.Text.Json.Serialization;
 

--- a/src/Views/Home/Index.cshtml
+++ b/src/Views/Home/Index.cshtml
@@ -39,7 +39,7 @@
       } else {
         <pre>
           @(Model.HttpException.ToString())
-          @(Model.HttpException.StackTrace.ToString())
+          @(Model.HttpException.StackTrace?.ToString())
         </pre>
       }
     </div>


### PR DESCRIPTION
Storage has flipped, so localtest should obviously follow in their footsteps

Now we do 
```
#nullable disable
```

in all files, instead of 

```
#nullable enable
```

in the updated files
