### PR TITLE
Fix MailingAddress and BusinessAddress to be full address.

### DIFF
--- a/testdata/Register/Org/043871668.json
+++ b/testdata/Register/Org/043871668.json
@@ -7,10 +7,10 @@
   "FaxNumber": "92110100",
   "EMailAddress": "epost@fjellet.no",
   "InternetAddress": "http://fjellbrl.no",
-  "MailingAddress": "Sofies Gate 21",
+  "MailingAddress": "Sofies Gate 21 0170 Oslo",
   "MailingPostalCode": "0170",
   "MailingPostalCity": "Oslo",
-  "BusinessAddress": "Sofies Gate 21",
+  "BusinessAddress": "Sofies Gate 21 0170 Oslo",
   "BusinessPostalCode": "0170",
-  "BusinessPostalCity": "By"
+  "BusinessPostalCity": "Oslo"
 }

--- a/testdata/Register/Org/405003309.json
+++ b/testdata/Register/Org/405003309.json
@@ -7,10 +7,10 @@
   "FaxNumber": "92110000",
   "EMailAddress": "localtest@digdir.no",
   "InternetAddress": "http://digdir.no",
-  "MailingAddress": "Lørenfaret 1C",
+  "MailingAddress": "Lørenfaret 1C 0580 Oslo",
   "MailingPostalCode": "0580",
   "MailingPostalCity": "Oslo",
-  "BusinessAddress": "Lørenfaret 1C",
+  "BusinessAddress": "Lørenfaret 1C 0580 Oslo",
   "BusinessPostalCode": "0580",
   "BusinessPostalCity": "Oslo"
 }

--- a/testdata/Register/Org/897069631.json
+++ b/testdata/Register/Org/897069631.json
@@ -7,10 +7,10 @@
   "FaxNumber": "92110000",
   "EMailAddress": "epost@setra.no",
   "InternetAddress": "http://setrabrl.no",
-  "MailingAddress": "Sofies Gate 2",
+  "MailingAddress": "Sofies Gate 2 0170 Oslo",
   "MailingPostalCode": "0170",
   "MailingPostalCity": "Oslo",
-  "BusinessAddress": "Sofies Gate 2",
+  "BusinessAddress": "Sofies Gate 2 0170 Oslo",
   "BusinessPostalCode": "0170",
-  "BusinessPostalCity": "By"
+  "BusinessPostalCity": "Oslo"
 }

--- a/testdata/Register/Org/897069650.json
+++ b/testdata/Register/Org/897069650.json
@@ -7,10 +7,10 @@
   "FaxNumber": "92110000",
   "EMailAddress": "central@ddgfitness.no",
   "InternetAddress": "http://ddgfitness.no",
-  "MailingAddress": "Sofies Gate 1",
+  "MailingAddress": "Sofies Gate 1 0170 Oslo",
   "MailingPostalCode": "0170",
   "MailingPostalCity": "Oslo",
-  "BusinessAddress": "Sofies Gate 1",
+  "BusinessAddress": "Sofies Gate 1 0170 Oslo",
   "BusinessPostalCode": "0170",
-  "BusinessPostalCity": "By"
+  "BusinessPostalCity": "Oslo"
 }

--- a/testdata/Register/Org/897069651.json
+++ b/testdata/Register/Org/897069651.json
@@ -7,10 +7,10 @@
   "FaxNumber": "92110001",
   "EMailAddress": "oslo@ddgfitness.no",
   "InternetAddress": "http://ddgfitness.no",
-  "MailingAddress": "Sofies Gate 1",
+  "MailingAddress": "Sofies Gate 1 0170 Oslo",
   "MailingPostalCode": "0170",
   "MailingPostalCity": "Oslo",
-  "BusinessAddress": "Sofies Gate 1",
+  "BusinessAddress": "Sofies Gate 1 0170 Oslo",
   "BusinessPostalCode": "0170",
-  "BusinessPostalCity": "By"
+  "BusinessPostalCity": "Oslo"
 }

--- a/testdata/Register/Org/897069652.json
+++ b/testdata/Register/Org/897069652.json
@@ -7,10 +7,10 @@
   "FaxNumber": "92110002",
   "EMailAddress": "bergen@ddgfitness.no",
   "InternetAddress": "http://ddgfitness.no",
-  "MailingAddress": "Olav Kyrres Gate 11",
+  "MailingAddress": "Olav Kyrres Gate 11 5014 Bergen",
   "MailingPostalCode": "5014",
   "MailingPostalCity": "Bergen",
-  "BusinessAddress": "Olav Kyrres Gate 11",
+  "BusinessAddress": "Olav Kyrres Gate 11 5014 Bergen",
   "BusinessPostalCode": "5014",
   "BusinessPostalCity": "Bergen"
 }

--- a/testdata/Register/Org/897069653.json
+++ b/testdata/Register/Org/897069653.json
@@ -7,10 +7,10 @@
   "FaxNumber": "92110003",
   "EMailAddress": "trondheim@ddgfitness.no",
   "InternetAddress": "http://ddgfitness.no",
-  "MailingAddress": "Kjøpmannsgata 25",
+  "MailingAddress": "Kjøpmannsgata 25 7013 Trondheim",
   "MailingPostalCode": "7013",
   "MailingPostalCity": "Trondheim",
-  "BusinessAddress": "Kjøpmannsgata 25",
+  "BusinessAddress": "Kjøpmannsgata 25 7013 Trondheim",
   "BusinessPostalCode": "7013",
   "BusinessPostalCity": "Trondheim"
 }

--- a/testdata/Register/Org/900000001.json
+++ b/testdata/Register/Org/900000001.json
@@ -7,10 +7,10 @@
   "FaxNumber": "12345678",
   "EMailAddress": "email@email.com",
   "InternetAddress": "http://example.com",
-  "MailingAddress": "Postadresse 9",
+  "MailingAddress": "Postadresse 9 0000 By",
   "MailingPostalCode": "0000",
   "MailingPostalCity": "By",
-  "BusinessAddress": "Forretningsadresse 9",
+  "BusinessAddress": "Forretningsadresse 9 0000 By",
   "BusinessPostalCode": "0000",
   "BusinessPostalCity": "By"
 }

--- a/testdata/Register/Org/910423185.json
+++ b/testdata/Register/Org/910423185.json
@@ -7,10 +7,10 @@
   "FaxNumber": "92110000",
   "EMailAddress": "lofoten@eashealt.no",
   "InternetAddress": "http://eashealt.no",
-  "MailingAddress": "Feskslogveien 12",
+  "MailingAddress": "Feskslogveien 12 8400 Svolvær",
   "MailingPostalCode": "8400",
   "MailingPostalCity": "Svolvær",
-  "BusinessAddress": "Feskslogveien 12",
+  "BusinessAddress": "Feskslogveien 12 8300 Svolvær",
   "BusinessPostalCode": "8300",
-  "BusinessPostalCity": "By"
+  "BusinessPostalCity": "Svolvær"
 }

--- a/testdata/Register/Org/910423495.json
+++ b/testdata/Register/Org/910423495.json
@@ -7,10 +7,10 @@
   "FaxNumber": "92110000",
   "EMailAddress": "lofoten@eashealt.no",
   "InternetAddress": "http://eashealt.no",
-  "MailingAddress": "Feskslogveien 12",
+  "MailingAddress": "Feskslogveien 12 8400 Svolvær",
   "MailingPostalCode": "8400",
   "MailingPostalCity": "Svolvær",
-  "BusinessAddress": "Feskslogveien 12",
+  "BusinessAddress": "Feskslogveien 12 4300 Svolvær",
   "BusinessPostalCode": "8300",
-  "BusinessPostalCity": "By"
+  "BusinessPostalCity": "Svolvær"
 }

--- a/testdata/Register/Org/910423495.json
+++ b/testdata/Register/Org/910423495.json
@@ -10,7 +10,6 @@
   "MailingAddress": "Feskslogveien 12 8400 Svolvær",
   "MailingPostalCode": "8400",
   "MailingPostalCity": "Svolvær",
-  "BusinessAddress": "Feskslogveien 12 4300 Svolvær",
-  "BusinessPostalCode": "8300",
+  "BusinessAddress": "Feskslogveien 12 8300 Svolvær",
   "BusinessPostalCity": "Svolvær"
 }

--- a/testdata/Register/Org/910457292.json
+++ b/testdata/Register/Org/910457292.json
@@ -7,10 +7,10 @@
   "FaxNumber": "92110000",
   "EMailAddress": "sortland@eashealt.no",
   "InternetAddress": "http://setrabrl.no",
-  "MailingAddress": "Strandgata 2",
+  "MailingAddress": "Strandgata 2 8400 Sortland",
   "MailingPostalCode": "8400",
   "MailingPostalCity": "Sortland",
-  "BusinessAddress": "Strandgata 2",
+  "BusinessAddress": "Strandgata 2 8400 Sortland",
   "BusinessPostalCode": "8400",
-  "BusinessPostalCity": "By"
+  "BusinessPostalCity": "Sortland"
 }

--- a/testdata/Register/Org/910471120.json
+++ b/testdata/Register/Org/910471120.json
@@ -7,10 +7,10 @@
   "FaxNumber": "92110000",
   "EMailAddress": "sortland@eashealt.no",
   "InternetAddress": "http://setrabrl.no",
-  "MailingAddress": "Strandgata 2",
+  "MailingAddress": "Strandgata 2 8450 Sortland",
   "MailingPostalCode": "8450",
   "MailingPostalCity": "Sortland",
-  "BusinessAddress": "Strandgata 2",
+  "BusinessAddress": "Strandgata 2 8450 Sortland",
   "BusinessPostalCode": "8450",
-  "BusinessPostalCity": "By"
+  "BusinessPostalCity": "Sortland"
 }

--- a/testdata/Register/Org/950474084.json
+++ b/testdata/Register/Org/950474084.json
@@ -7,10 +7,10 @@
   "FaxNumber": "92110000",
   "EMailAddress": "epost@setra.no",
   "InternetAddress": "http://setrabrl.no",
-  "MailingAddress": "Sofies Gate 2",
+  "MailingAddress": "Sofies Gate 2 0170 Oslo",
   "MailingPostalCode": "0170",
   "MailingPostalCity": "Oslo",
-  "BusinessAddress": "Sofies Gate 2",
+  "BusinessAddress": "Sofies Gate 2 0170 Oslo",
   "BusinessPostalCode": "0170",
-  "BusinessPostalCity": "By"
+  "BusinessPostalCity": "Oslo"
 }


### PR DESCRIPTION
Apparently Register has a standard that `MailingAddress` and `BusinessAddress` used for prefill should be the full address (for some reason space separated, not `\n` separated). Localtest should obviously reflect this.

Persons seems to have been previously fixed, so only orgs are left.
